### PR TITLE
feat: app-invite plugin

### DIFF
--- a/packages/plugins/app-invite/LICENSE.md
+++ b/packages/plugins/app-invite/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2025 Joél de Oliveira Solano da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/plugins/app-invite/README.md
+++ b/packages/plugins/app-invite/README.md
@@ -1,6 +1,267 @@
 # @better-auth-extended/app-invite
 
-Invite users to your application and allow them to sign up.
+The App Invite plugin enables you to invite users to your application through email invitations. It supports two types of invitations:
+
+- **Personal Invitations**: Targeted to specific email addresses, ensuring only the intended recipient can use the invitation
+- **Public Invitations**: Can be used by multiple users, making it ideal for open sign-up scenarios
+
+This plugin is particularly useful for invite-only applications.
+
+## Installation
+
+### 1. Install the plugin
+
+```bash
+npm install @better-auth-extended/app-invite
+```
+
+### 2. Add the plugin to your auth config
+
+To use the App Invite plugin, add it to your auth config.
+
+```ts
+import { betterAuth } from "better-auth";
+import { appInvite } from "@better-auth-extended/app-invite";
+
+export const auth = betterAuth({
+  // ... other config options
+  plugins: [
+    appInvite({
+      // required for personal invites
+      sendInvitationEmail: (data) => {
+        // ... send invitation to the user
+      },
+    }),
+  ],
+});
+```
+
+### 3. Add the client plugin
+
+Include the App Invite client plugin in your authentication client instance.
+
+```ts
+import { createAuthClient } from "better-auth/client";
+import { appInviteClient } from "@better-auth-extended/app-invite/client";
+
+const authClient = createAuthClient({
+  plugins: [appInviteClient()],
+});
+```
+
+### 4. Run migrations
+
+This plugin adds an additional table to the database. [Click here to see the schema](#schema)
+
+```bash
+npx @better-auth/cli migrate
+```
+
+or generate
+
+```bash
+npx @better-auth/cli generate
+```
+
+## Usage
+
+To add members to the application, we first need to send an invitation to the user.
+The user will receive an email with the invitation link. Once the user accepts the invitation, they will be signed up to the application.
+
+### Setup Invitation Email
+
+For personal invites to work we first need to provide `sendInvitationEmail` to the `better-auth` instance.
+This function is responsible for sending the invitation email to the user.
+
+You'll need to construct and send the invitation link to the user. The link should include the invitation ID,
+which will be used with the `acceptInvitation` function when the user clicks on it.
+
+This is only required for personal invites. Sharing public invitations is up to the inviter.
+
+```ts
+import { betterAuth } from "better-auth";
+import { appInvite } from "@better-auth-extended/app-invite";
+import { sendAppInvitation } from "./email";
+
+export const auth = betterAuth({
+  plugins: [
+    appInvite({
+      async sendInvitationEmail(data) {
+        const inviteLink = `https://example.com/accept-invitation/${data.id}`;
+        sendAppInvitation({
+          name: data.name,
+          email: data.email,
+          invitedByUsername: data.inviter.name,
+          invitedByEmail: data.inviter.email,
+          inviteLink,
+        });
+      },
+    }),
+  ],
+});
+```
+
+### Send Invitation
+
+To invite users to the app, you can use the `invite` function provided by the client.
+the `invite` function takes an object with the following properties:
+
+- `email`: The email address of the user to invite. Leave empty to create a public invitation.
+- `resend`: A boolean value that determines whether to resend the invitation email,
+  if the user is already invited. Defaults to `false`
+- `domainWhitelist`: An optional comma separated list of domains that allows public invitations
+  to be accepted only from approved domains.
+
+```ts
+await authClient.inviteUser({
+  email: "test@email.com",
+});
+```
+
+### Accept Invitation
+
+When a user receives an invitation email, they can click on the invitation link to accept the invitation.
+The link should include the invitation ID, which will be used to accept the invitation.
+
+```ts
+await authClient.acceptInvitation({
+  invitationId: "invitation-id",
+  name: "John Doe", // overridden if predefined in the invitation
+  email: "test@email.com", // must be set for public invites
+  password: "password123456",
+});
+```
+
+### Update Invitation Status
+
+To update the status of invitations you can use the `acceptInvitation`, `rejectInvitation`, `cancelInvitation`
+function provided by the client. The functions take the invitation id as an argument.
+
+```ts
+// cancel invitation (by default only the inviter can cancel invitations)
+await authClient.cancelInvitation({
+  invitationId: "invitation-id",
+});
+
+// reject invitation (this is only available for personal invites)
+await authClient.rejectInvitation({
+  invitationId: "invitation-id",
+});
+```
+
+### Get Invitation
+
+To get an invitation you can use the `getAppInvitation` function provided by the client. You need to provide the
+invitation id as a query parameter.
+
+```ts
+await authClient.getAppInvitation({
+  query: {
+    id: params.id,
+  },
+});
+```
+
+### List Invitations
+
+Allows an user to list all invitations issued by themself.
+
+```ts
+await authClient.listInvitations({
+  query: {
+    limit: 10,
+  },
+});
+```
+
+By default 100 invitations are returned. You can adjust the limit and offset using the following query parameters:
+
+- `searchField`: The field to search on, which can be `email`, `name` or `domainWhitelist`.
+- `searchOperator`: The operator to use for the search. It can be `contains`, `starts_with`, or `ends_with`.
+- `searchValue`: The value to search for.
+- `limit`: The number of invitations to return.
+- `offset`: The number of invitations to skip.
+- `sortBy`: The field to sort the invitations by.
+- `sortDirection`: The direction to sort the invitations by. Defaults to `asc`.
+- `filterField`: The field to filter the invitations by.
+- `filterOperator`: The operator to use for the filter. It can be `eq`, `ne`, `lt`, `lte`, `gt` or `gte`.
+- `filterValue`: The value to filter the invitations by.
+
+```ts
+await authClient.listInvitations({
+  query: {
+    searchField: "domainWhitelist",
+    searchOperator: "contains",
+    searchValue: "example.com",
+    limit: 10,
+    offset: 0,
+    sortBy: "createdAt",
+    sortDirection: "desc",
+    filterField: "expiresAt",
+    filterOperator: "lt",
+    filterValue: new Date().toISOString(),
+  },
+});
+```
+
+## Schema
+
+The plugin requires an additional table in the database.
+
+Table Name: `appInvitation`
+
+| Field Name      | Type     | Key  | Description                                                    |
+| --------------- | -------- | ---- | -------------------------------------------------------------- |
+| id              | `string` | `PK` | Unique identifier for each invitation                          |
+| name            | `string` | `?`  | The name of the user                                           |
+| email           | `string` | `?`  | The email address of the user                                  |
+| inviterId       | `string` | `FK` | The ID of the inviter                                          |
+| status          | `string` |      | The status of the invitation                                   |
+| domainWhitelist | `string` | `?`  | A comma separated whitelist of domains for a public invitation |
+| expiresAt       | `Date`   | `?`  | Timestamp of when the invitation expires                       |
+| createdAt       | `Date`   |      | Timestamp of when the invitation was created                   |
+
+## Options
+
+**canCreateInvitation**: `((ctx: GenericEndpointContext) => Promise<boolean> | boolean)` | `boolean` - A function that determines whether a user can create an invitation. By default, it's `true`. You can set it to `false` to restrict users from creating invitations.
+
+**canCancelInvitation** `((ctx: GenericEndpointContext, invite: AppInvitation) => Promise<boolean> | boolean)` | `boolean` - A function that determines whether a user can cancel invitations. By default the user can only cancel invites created by themselves. You can set it to `false` to restrict users from canceling invitations.
+
+**sendInvitationEmail**: `async (data) => Promise<void>` - A function that sends an invitation email to the user. This is only required for personal invitations.
+
+**invitationExpiresIn**: `number` - How long the invitation link is valid for in seconds. By default an invitation expires after 48 hours (2 days). Set it to `null` to prevent invitations from expiring.
+
+**autoSignIn**: `boolean` - A boolean value that determines whether to prevent automatic sign-up when accepting an invitation. Defaults to `false`.
+
+**cleanupExpiredInvitations**: `boolean` - Clean up expired invitations when a value is fetched. Default `true`.
+
+**cleanupPersonalInvitesOnDecision**: `boolean` - Cleanup personal invitations when a decision is made. Default `false`.
+
+**verifyEmailOnAccept**: `boolean` - Whether to verify email addresses when accepting invitations. Default `true`.
+
+**resendExistingInvite**: `boolean` - Whether to resend existing invitations, instead of creating a new one. Default `false`.
+
+**hooks.create.before**: `(ctx: GenericEndpointContext) => Promise<void> | void` - A function that runs before an invitation is created.
+
+**hooks.create.after**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs after an invitation was created.
+
+**hooks.accept.before**: `(ctx: GenericEndpointContext, userToCreate: Partial<User> & { email: string }) => Promise<{ user?: User; } | void> | { user?: User; } | void;` - A function that runs before an invitation is accepted.
+
+**hooks.accept.after**: `(ctx: GenericEndpointContext, data: { invitation: AppInvitation; user: User; }) => Promise<void> | void` - A function that runs after an invitation was accepted.
+
+**hooks.reject.before**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs before an invitation is rejected.
+
+**hooks.reject.after**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs after an invitation was rejected.
+
+**hooks.cancel.before**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs before an invitation is canceled.
+
+**hooks.cancel.after**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs after an invitation was canceled.
+
+**schema**: The schema for the app-invite plugin. Allows you to infer additional fields for `user` and `appInvitation` table. This option is available in the client plugin aswell.
+
+~~**allowUserToCreateInvitation**~~: `boolean` | `((user: User, type: "personal" | "public") => Promise<boolean> | boolean)` - A function that determines whether a user can create invite others. By defaults it's `true`. You can set it to `false` to restrict users from creating invitations. (deprecated. use `canCreateInvitation` instead.)
+
+~~**allowUserToCancelInvitation**~~: `(data: { user: User, invitation: AppInvitation }) => Promise<boolean> | boolean` - A functon that determines whether a user can cancel inivtations. By default the user can only cancel invites created by them. You can set it to `false` to restrict users from canceling invitations. (deprecated. use `canCancelInvitation` instead.)
 
 ## License
 

--- a/packages/plugins/app-invite/README.md
+++ b/packages/plugins/app-invite/README.md
@@ -1,1 +1,7 @@
 # @better-auth-extended/app-invite
+
+Invite users to your application and allow them to sign up.
+
+## License
+
+[MIT](LICENSE.md)

--- a/packages/plugins/app-invite/README.md
+++ b/packages/plugins/app-invite/README.md
@@ -109,8 +109,7 @@ the `invite` function takes an object with the following properties:
 - `email`: The email address of the user to invite. Leave empty to create a public invitation.
 - `resend`: A boolean value that determines whether to resend the invitation email,
   if the user is already invited. Defaults to `false`
-- `domainWhitelist`: An optional comma separated list of domains that allows public invitations
-  to be accepted only from approved domains.
+- `domainWhitelist`: An optional comma-separated list of domains that allows public invitations to be accepted only from approved domains (e.g., `example.com,*.example.org`).
 
 ```ts
 await authClient.inviteUser({
@@ -164,7 +163,7 @@ await authClient.getAppInvitation({
 
 ### List Invitations
 
-Allows an user to list all invitations issued by themself.
+Allows a user to list all invitations issued by themselves.
 
 ```ts
 await authClient.listInvitations({
@@ -176,7 +175,7 @@ await authClient.listInvitations({
 
 By default 100 invitations are returned. You can adjust the limit and offset using the following query parameters:
 
-- `searchField`: The field to search on, which can be `email`, `name` or `domainWhitelist`.
+- `searchField`: The field to search on, which can be `email`, `name`, or `domainWhitelist`.
 - `searchOperator`: The operator to use for the search. It can be `contains`, `starts_with`, or `ends_with`.
 - `searchValue`: The value to search for.
 - `limit`: The number of invitations to return.
@@ -184,7 +183,7 @@ By default 100 invitations are returned. You can adjust the limit and offset usi
 - `sortBy`: The field to sort the invitations by.
 - `sortDirection`: The direction to sort the invitations by. Defaults to `asc`.
 - `filterField`: The field to filter the invitations by.
-- `filterOperator`: The operator to use for the filter. It can be `eq`, `ne`, `lt`, `lte`, `gt` or `gte`.
+- `filterOperator`: The operator to use for the filter. It can be `eq`, `ne`, `lt`, `lte`, `gt`, or `gte`.
 - `filterValue`: The value to filter the invitations by.
 
 ```ts
@@ -225,7 +224,7 @@ Table Name: `appInvitation`
 
 **canCreateInvitation**: `((ctx: GenericEndpointContext) => Promise<boolean> | boolean)` | `boolean` - A function that determines whether a user can create an invitation. By default, it's `true`. You can set it to `false` to restrict users from creating invitations.
 
-**canCancelInvitation** `((ctx: GenericEndpointContext, invite: AppInvitation) => Promise<boolean> | boolean)` | `boolean` - A function that determines whether a user can cancel invitations. By default the user can only cancel invites created by themselves. You can set it to `false` to restrict users from canceling invitations.
+**canCancelInvitation** `((ctx: GenericEndpointContext, invite: AppInvitation) => Promise<boolean> | boolean)` | `boolean` - A function that determines whether a user can cancel invitations. By default, the user can only cancel invites they created. You can set it to `false` to restrict users from canceling invitations.
 
 **sendInvitationEmail**: `async (data) => Promise<void>` - A function that sends an invitation email to the user. This is only required for personal invitations.
 
@@ -259,7 +258,7 @@ Table Name: `appInvitation`
 
 **schema**: The schema for the app-invite plugin. Allows you to infer additional fields for the `user` and `appInvitation` tables. This option is available in the client plugin as well.
 
-~~**allowUserToCreateInvitation**~~: `boolean` | `((user: User, type: "personal" | "public") => Promise<boolean> | boolean)` - A function that determines whether a user can create invite others. By defaults it's `true`. You can set it to `false` to restrict users from creating invitations. (deprecated. use `canCreateInvitation` instead.)
+~~**allowUserToCreateInvitation**~~: `boolean` | `((user: User, type: "personal" | "public") => Promise<boolean> | boolean)` - A function that determines whether a user can invite others. By defaults it's `true`. You can set it to `false` to restrict users from creating invitations. (deprecated. use `canCreateInvitation` instead.)
 
 ~~**allowUserToCancelInvitation**~~: `(data: { user: User, invitation: AppInvitation }) => Promise<boolean> | boolean` - A function that determines whether a user can cancel invitations. By default the user can only cancel invites created by them. You can set it to `false` to restrict users from canceling invitations. (deprecated. use `canCancelInvitation` instead.)
 

--- a/packages/plugins/app-invite/README.md
+++ b/packages/plugins/app-invite/README.md
@@ -257,11 +257,11 @@ Table Name: `appInvitation`
 
 **hooks.cancel.after**: `(ctx: GenericEndpointContext, invitation: AppInvitation) => Promise<void> | void` - A function that runs after an invitation was canceled.
 
-**schema**: The schema for the app-invite plugin. Allows you to infer additional fields for `user` and `appInvitation` table. This option is available in the client plugin aswell.
+**schema**: The schema for the app-invite plugin. Allows you to infer additional fields for the `user` and `appInvitation` tables. This option is available in the client plugin as well.
 
 ~~**allowUserToCreateInvitation**~~: `boolean` | `((user: User, type: "personal" | "public") => Promise<boolean> | boolean)` - A function that determines whether a user can create invite others. By defaults it's `true`. You can set it to `false` to restrict users from creating invitations. (deprecated. use `canCreateInvitation` instead.)
 
-~~**allowUserToCancelInvitation**~~: `(data: { user: User, invitation: AppInvitation }) => Promise<boolean> | boolean` - A functon that determines whether a user can cancel inivtations. By default the user can only cancel invites created by them. You can set it to `false` to restrict users from canceling invitations. (deprecated. use `canCancelInvitation` instead.)
+~~**allowUserToCancelInvitation**~~: `(data: { user: User, invitation: AppInvitation }) => Promise<boolean> | boolean` - A function that determines whether a user can cancel invitations. By default the user can only cancel invites created by them. You can set it to `false` to restrict users from canceling invitations. (deprecated. use `canCancelInvitation` instead.)
 
 ## License
 

--- a/packages/plugins/app-invite/README.md
+++ b/packages/plugins/app-invite/README.md
@@ -1,0 +1,1 @@
+# @better-auth-extended/app-invite

--- a/packages/plugins/app-invite/build.config.ts
+++ b/packages/plugins/app-invite/build.config.ts
@@ -1,0 +1,18 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+	declaration: true,
+	rollup: {
+		emitCJS: false,
+		dts: {
+			respectExternal: true,
+			compilerOptions: {
+				preserveSymlinks: true,
+			},
+		},
+	},
+	outDir: "dist",
+	clean: false,
+	failOnWarn: false,
+	externals: ["better-auth", "better-call", "@better-fetch/fetch"],
+});

--- a/packages/plugins/app-invite/package.json
+++ b/packages/plugins/app-invite/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@better-auth-extended/app-invite",
+	"description": "",
+	"version": "0.0.1",
+	"type": "module",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jslno/better-auth-extended",
+		"directory": "packages/plugin/app-invite"
+	},
+	"license": "MIT",
+	"keywords": [],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "unbuild --clean",
+		"dev": "unbuild --watch",
+		"stub": "unbuild --stub",
+		"test": "vitest",
+		"typecheck": "tsc --noEmit"
+	},
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.mjs",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.cjs"
+		},
+		"./client": {
+			"types": "./dist/client.d.ts",
+			"import": "./dist/client.mjs",
+			"require": "./dist/client.cjs"
+		}
+	},
+	"typesVersions": {
+		"*": {
+			"*": [
+				"./dist/index.d.ts"
+			],
+			"client": [
+				"./dist/client.d.ts"
+			]
+		}
+	},
+	"devDependencies": {
+		"@better-auth-extended/test-utils": "workspace:*",
+		"better-auth": "catalog:better-auth",
+		"typescript": "catalog:",
+		"unbuild": "catalog:",
+		"vitest": "catalog:",
+		"better-call": "catalog:"
+	},
+	"peerDependencies": {
+		"better-auth": "catalog:better-auth"
+	},
+	"dependencies": {
+		"@better-auth-extended/internal-env": "workspace:*",
+		"@better-auth-extended/internal-utils": "workspace:*",
+		"zod": "catalog:"
+	},
+	"files": [
+		"dist"
+	]
+}

--- a/packages/plugins/app-invite/package.json
+++ b/packages/plugins/app-invite/package.json
@@ -1,66 +1,66 @@
 {
-	"name": "@better-auth-extended/app-invite",
-	"description": "",
-	"version": "0.0.1",
-	"type": "module",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/jslno/better-auth-extended",
-		"directory": "packages/plugin/app-invite"
-	},
-	"license": "MIT",
-	"keywords": [],
-	"publishConfig": {
-		"access": "public"
-	},
-	"scripts": {
-		"build": "unbuild --clean",
-		"dev": "unbuild --watch",
-		"stub": "unbuild --stub",
-		"test": "vitest",
-		"typecheck": "tsc --noEmit"
-	},
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.mjs",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.cjs"
-		},
-		"./client": {
-			"types": "./dist/client.d.ts",
-			"import": "./dist/client.mjs",
-			"require": "./dist/client.cjs"
-		}
-	},
-	"typesVersions": {
-		"*": {
-			"*": [
-				"./dist/index.d.ts"
-			],
-			"client": [
-				"./dist/client.d.ts"
-			]
-		}
-	},
-	"devDependencies": {
-		"@better-auth-extended/test-utils": "workspace:*",
-		"better-auth": "catalog:better-auth",
-		"typescript": "catalog:",
-		"unbuild": "catalog:",
-		"vitest": "catalog:",
-		"better-call": "catalog:"
-	},
-	"peerDependencies": {
-		"better-auth": "catalog:better-auth"
-	},
-	"dependencies": {
-		"@better-auth-extended/internal-env": "workspace:*",
-		"@better-auth-extended/internal-utils": "workspace:*",
-		"zod": "catalog:"
-	},
-	"files": [
-		"dist"
-	]
+  "name": "@better-auth-extended/app-invite",
+  "description": "",
+  "version": "0.0.1",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jslno/better-auth-extended",
+    "directory": "packages/plugin/app-invite"
+  },
+  "license": "MIT",
+  "keywords": [],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "dev": "unbuild --watch",
+    "stub": "unbuild --stub",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.mjs",
+      "require": "./dist/client.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.ts"
+      ],
+      "client": [
+        "./dist/client.d.ts"
+      ]
+    }
+  },
+  "devDependencies": {
+    "@better-auth-extended/test-utils": "workspace:*",
+    "better-auth": "catalog:better-auth",
+    "typescript": "catalog:",
+    "unbuild": "catalog:",
+    "vitest": "catalog:",
+    "better-call": "catalog:"
+  },
+  "peerDependencies": {
+    "better-auth": "catalog:better-auth"
+  },
+  "dependencies": {
+    "@better-auth-extended/internal-env": "workspace:*",
+    "@better-auth-extended/internal-utils": "workspace:*",
+    "zod": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/plugins/app-invite/src/adapter.ts
+++ b/packages/plugins/app-invite/src/adapter.ts
@@ -136,9 +136,7 @@ export const getAppInviteAdapter = (
 				...data,
 			});
 		},
-		countInvitations: async (data?: {
-			where?: Where[];
-		}) => {
+		countInvitations: async (data?: { where?: Where[] }) => {
 			return adapter.count({
 				model: "appInvitation",
 				...data,

--- a/packages/plugins/app-invite/src/adapter.ts
+++ b/packages/plugins/app-invite/src/adapter.ts
@@ -100,6 +100,36 @@ export const getAppInviteAdapter = (
 			});
 			return invitation;
 		},
+		findInvitationsByEmail: async <
+			AdditionalFields extends Record<string, any>,
+		>(
+			email: string,
+			data?: {
+				where?: Where[];
+				sortBy?: {
+					field: string;
+					direction: "asc" | "desc";
+				};
+				limit?: number;
+				offset?: number;
+			},
+		) => {
+			const invitations = await adapter.findMany<
+				AppInvitation & AdditionalFields
+			>({
+				model: "appInvitation",
+				...data,
+				where: [
+					{
+						field: "email",
+						value: email,
+					},
+					...(data?.where ?? []),
+				],
+			});
+
+			return invitations;
+		},
 		updateInvitation: async <AdditionalFields extends Record<string, any>>(
 			id: string,
 			status: Exclude<AppInvitationStatus, "pending">,

--- a/packages/plugins/app-invite/src/adapter.ts
+++ b/packages/plugins/app-invite/src/adapter.ts
@@ -1,0 +1,159 @@
+import type { AuthContext, User, Where } from "better-auth";
+import type { AppInviteOptions } from "./types";
+import type {
+	AppInvitation,
+	AppInvitationInput,
+	AppInvitationStatus,
+	CreateInvitation,
+} from "./schema";
+import { getDate } from "@better-auth-extended/internal-utils";
+
+type WithAdditionalFields<
+	T,
+	AdditionalFields extends Record<string, any> = Record<string, any>,
+> = T & {
+	additionalFields?: {} | AdditionalFields;
+};
+
+export const getAppInviteAdapter = (
+	context: AuthContext,
+	options?: AppInviteOptions,
+) => {
+	const adapter = context.adapter;
+
+	return {
+		createInvitation: async <AdditionalFields extends Record<string, any>>(
+			invitation: WithAdditionalFields<CreateInvitation, AdditionalFields>,
+			user: User,
+		) => {
+			const defaultExpiration = 1000 * 60 * 60 * 48;
+			const expiresAt =
+				options?.invitationExpiresIn === null
+					? undefined
+					: getDate(options?.invitationExpiresIn || defaultExpiration);
+
+			const newInvite = await adapter.create<AppInvitationInput, AppInvitation>(
+				{
+					model: "appInvitation",
+					data: {
+						inviterId: user.id,
+						status: "pending",
+						expiresAt,
+						...(invitation.type === "personal"
+							? {
+									name: invitation.name,
+									email: invitation.email,
+								}
+							: {
+									domainWhitelist: Array.isArray(invitation.domainWhitelist)
+										? invitation.domainWhitelist.join(",")
+										: invitation.domainWhitelist,
+								}),
+						...invitation.additionalFields,
+					},
+				},
+			);
+
+			const data = {
+				...newInvite,
+			} as AppInvitation & AdditionalFields;
+
+			return data;
+		},
+		findInvitationById: async <AdditionalFields extends Record<string, any>>(
+			id: string,
+			data?: {
+				where?: Where[];
+			},
+		) => {
+			const invitation = await adapter.findOne<
+				AppInvitation & AdditionalFields
+			>({
+				model: "appInvitation",
+				where: [
+					{
+						field: "id",
+						value: id,
+					},
+					...(data?.where ?? []),
+				],
+			});
+			return invitation;
+		},
+		findInvitationByEmail: async <AdditionalFields extends Record<string, any>>(
+			email: string,
+			data?: {
+				where?: Where[];
+			},
+		) => {
+			const invitation = await adapter.findOne<
+				AppInvitation & AdditionalFields
+			>({
+				model: "appInvitation",
+				where: [
+					{
+						field: "email",
+						value: email,
+					},
+					...(data?.where ?? []),
+				],
+			});
+			return invitation;
+		},
+		updateInvitation: async <AdditionalFields extends Record<string, any>>(
+			id: string,
+			status: Exclude<AppInvitationStatus, "pending">,
+		) => {
+			const invitation = await adapter.update<AppInvitation & AdditionalFields>(
+				{
+					model: "appInvitation",
+					where: [
+						{
+							field: "id",
+							value: id,
+						},
+					],
+					update: {
+						status,
+					},
+				},
+			);
+			return invitation;
+		},
+		listInvitations: async <
+			AdditionalFields extends Record<string, any>,
+		>(data?: {
+			limit?: number;
+			offset?: number;
+			sortBy?: {
+				field: string;
+				direction: "asc" | "desc";
+			};
+			where?: Where[];
+		}) => {
+			return adapter.findMany<AppInvitation & AdditionalFields>({
+				model: "appInvitation",
+				...data,
+			});
+		},
+		countInvitations: async (data?: {
+			where?: Where[];
+		}) => {
+			return adapter.count({
+				model: "appInvitation",
+				...data,
+			});
+		},
+		deleteInvitation: async (id: string) => {
+			await adapter.delete({
+				model: "appInvitation",
+				where: [
+					{
+						field: "id",
+						value: id,
+					},
+				],
+			});
+		},
+	};
+};

--- a/packages/plugins/app-invite/src/adapter.ts
+++ b/packages/plugins/app-invite/src/adapter.ts
@@ -30,7 +30,7 @@ export const getAppInviteAdapter = (
 			const expiresAt =
 				options?.invitationExpiresIn === null
 					? undefined
-					: getDate(options?.invitationExpiresIn || defaultExpiration);
+					: getDate(options?.invitationExpiresIn ?? defaultExpiration);
 
 			const newInvite = await adapter.create<AppInvitationInput, AppInvitation>(
 				{
@@ -45,9 +45,12 @@ export const getAppInviteAdapter = (
 									email: invitation.email,
 								}
 							: {
-									domainWhitelist: Array.isArray(invitation.domainWhitelist)
-										? invitation.domainWhitelist.join(",")
-										: invitation.domainWhitelist,
+									domainWhitelist: (Array.isArray(invitation.domainWhitelist)
+										? invitation.domainWhitelist
+										: invitation.domainWhitelist?.split(",")
+									)
+										?.map((d) => d.trim().toLowerCase())
+										.join(","),
 								}),
 						...invitation.additionalFields,
 					},

--- a/packages/plugins/app-invite/src/adapter.ts
+++ b/packages/plugins/app-invite/src/adapter.ts
@@ -150,6 +150,24 @@ export const getAppInviteAdapter = (
 			);
 			return invitation;
 		},
+		updateInvitations: async (
+			ids: string[],
+			status: Exclude<AppInvitationStatus, "pending">,
+		) => {
+			return await adapter.updateMany({
+				model: "appInvitation",
+				where: [
+					{
+						field: "id",
+						value: ids,
+						operator: "in",
+					},
+				],
+				update: {
+					status,
+				},
+			});
+		},
 		listInvitations: async <
 			AdditionalFields extends Record<string, any>,
 		>(data?: {
@@ -179,6 +197,18 @@ export const getAppInviteAdapter = (
 					{
 						field: "id",
 						value: id,
+					},
+				],
+			});
+		},
+		deleteInvitations: async (ids: string[]) => {
+			return await adapter.deleteMany({
+				model: "appInvitation",
+				where: [
+					{
+						field: "id",
+						value: ids,
+						operator: "in",
 					},
 				],
 			});

--- a/packages/plugins/app-invite/src/app-invite.test.ts
+++ b/packages/plugins/app-invite/src/app-invite.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "@better-auth-extended/test-utils";
+import { appInvite } from "./index";
+import { appInviteClient } from "./client";
+import { createAuthClient } from "better-auth/client";
+import { inferAdditionalFields } from "better-auth/client/plugins";
+import { APP_INVITE_ERROR_CODES } from "./error-codes";
+
+const mockFn = vi.fn();
+describe("App Invite", async () => {
+	const { auth, client, signUpWithTestUser, sessionSetter, db, customFetchImpl, signInWithUser } =
+		await getTestInstance({
+			options: {
+				account: {
+					fields: {
+						providerId: "provider_id",
+						accountId: "account_id",
+					},
+				},
+				user: {
+					additionalFields: {
+						newField: {
+							type: "string",
+							defaultValue: "default-value",
+						},
+						nonRequiredField: {
+							type: "string",
+							required: false,
+						},
+					},
+				},
+				emailAndPassword: {
+					enabled: true,
+					autoSignIn: true,
+				},
+				plugins: [
+					appInvite({
+						autoSignIn: true,
+						canCreateInvitation: (ctx) => {
+							return ctx.context.session?.user.email !== "test7@test.com";
+						},
+						sendInvitationEmail: async (data, request) => {
+							mockFn(data);
+						},
+						schema: {
+							appInvitation: {
+								additionalFields: {
+									newInviteField: {
+										type: "string",
+										required: true,
+									},
+									nonRequiredInviteField: {
+										type: "string",
+										required: false,
+									},
+								},
+							},
+							user: {
+								additionalFields: {
+									newField: {
+										type: "string",
+										required: true,
+									},
+									nonRequiredField: {
+										type: "string",
+										required: false,
+									},
+								},
+							},
+						},
+					}),
+				],
+			},
+			clientOptions: {
+				plugins: [
+					appInviteClient({
+						schema: {
+							appInvitation: {
+								additionalFields: {
+									newInviteField: {
+										type: "string",
+										required: true,
+									},
+									nonRequiredInviteField: {
+										type: "string",
+										required: false,
+									},
+								},
+							},
+							user: {
+								additionalFields: {
+									newField: {
+										type: "string",
+										required: true,
+									},
+									nonRequiredField: {
+										type: "string",
+										required: false,
+									},
+								},
+							},
+						},
+					}),
+					inferAdditionalFields({
+						user: {
+							newField: {
+								type: "string",
+							},
+							nonRequiredField: {
+								type: "string",
+								required: false,
+							},
+						},
+					}),
+				],
+			},
+		});
+	const context = await auth.$context;
+	const user = await signUpWithTestUser();
+
+	describe("Sign up with invitation", () => {
+		it("should work with additional fields on the user table", async () => {
+			const invitation = await auth.api.createAppInvitation({
+				headers: user.headers,
+				body: {
+					type: "personal",
+					email: "email1@test.com",
+					name: "Test User",
+					additionalFields: {
+						newInviteField: "",
+						nonRequiredInviteField: "",
+					},
+				},
+			});
+			const headers = new Headers();
+			const res = await client.acceptInvitation(
+				{
+					invitationId: invitation.id,
+					password: "password",
+					additionalFields: {
+						newField: "new-field",
+					},
+				},
+				{
+					onSuccess: sessionSetter(headers),
+				},
+			);
+
+			expect(res.data?.token).toBeDefined();
+			expect(res.data?.user.email).toBe("email1@test.com");
+			expect(res.data?.user.name).toBe("Test User");
+			const accounts = await context.internalAdapter.findAccountByUserId(res.data!.user.id);
+			expect(accounts).toHaveLength(1);
+
+			const session = await client.getSession({
+				fetchOptions: {
+					headers,
+					throw: true,
+				},
+			});
+			expect(session?.user.newField).toBe("new-field");
+		});
+		it("should work with custom fields on account table", async () => {
+			const invitation = await auth.api.createAppInvitation({
+				headers: user.headers,
+				body: {
+					type: "personal",
+					email: "email2@test.com",
+					additionalFields: {
+						newInviteField: "",
+						nonRequiredInviteField: "",
+					},
+				},
+			});
+			const res = await auth.api.acceptAppInvitation({
+				body: {
+					invitationId: invitation.id,
+					name: "Test Name",
+					password: "password",
+					additionalFields: {
+						newField: "",
+						nonRequiredField: "",
+					},
+				},
+			});
+			expect(res.token).toBeDefined();
+			const accounts = await context.internalAdapter.findAccountByUserId(res.user.id);
+			expect(accounts).toHaveLength(1);
+		});
+		it("should not work with invalid invitation", async () => {
+			const res = await auth.api
+				.acceptAppInvitation({
+					body: {
+						invitationId: "not a valid id",
+						name: "Test Name",
+						password: "password",
+						additionalFields: {
+							newField: "",
+							nonRequiredField: "",
+						},
+					},
+				})
+				.catch((e) => {});
+			expect(res).toBeUndefined();
+		});
+	});
+
+	const client2 = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [
+			appInviteClient({
+				schema: {
+					appInvitation: {
+						additionalFields: {
+							newInviteField: {
+								type: "string",
+								required: true,
+							},
+							nonRequiredInviteField: {
+								type: "string",
+								required: false,
+							},
+						},
+					},
+					user: {
+						additionalFields: {
+							newField: {
+								type: "string",
+								required: true,
+							},
+							nonRequiredField: {
+								type: "string",
+								required: false,
+							},
+						},
+					},
+				},
+			}),
+		],
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	it("should allow inviting users to the application", async () => {
+		const newUser = {
+			email: "test3@test.com",
+		};
+		const invite = await client.inviteUser({
+			type: "personal",
+			email: newUser.email,
+			additionalFields: {
+				newInviteField: "",
+				nonRequiredInviteField: "",
+			},
+			fetchOptions: {
+				headers: user.headers,
+			},
+		});
+		if (!invite.data) throw new Error("Invitation not created");
+		expect(invite.data.email).toBe(newUser.email);
+	});
+
+	describe("should allow inviting multiple users with a single link", async () => {
+		const invitation = await auth.api.createAppInvitation({
+			body: {
+				type: "public",
+				domainWhitelist: "test*.com",
+				additionalFields: {
+					newInviteField: "",
+					nonRequiredInviteField: "",
+				},
+			},
+			headers: user.headers,
+		});
+		if (!invitation) {
+			throw new Error("Couldn't create invitation");
+		}
+		expect(invitation?.status).toBe("pending");
+
+		it.each(
+			[
+				{
+					invitee: {
+						name: "Test User #1",
+						email: "test-user-1@test.com",
+						password: "password123456",
+					},
+					action: "accept-invitation",
+					message: "$name should be able to accept the invitation",
+				},
+				{
+					invitee: {
+						name: "Test User #2",
+						email: "test-user-2@test2.com",
+						password: "password123456",
+					},
+					action: "accept-invitation",
+					message: "$name should be able to accept the invitation",
+				},
+				{
+					invitee: {
+						name: "Test User #3",
+						email: "test-user-3@example.com",
+						password: "password123456",
+					},
+					action: "accept-invitation-expect-error",
+					message:
+						"$name should not be able to accept the invitation (domain not in whitelist)",
+				},
+				{
+					action: "reject-invitation",
+					message: "should not allow to reject the invitation",
+				},
+			].map(({ action, message, ...data }) => [
+				`${message?.replaceAll(/\$name/g, () => `'${data.invitee?.name}'`) || action}`,
+				action,
+				data,
+			]),
+		)("%s", async (_, action, { invitee }) => {
+			switch (action) {
+				case "accept-invitation-expect-error":
+				case "accept-invitation": {
+					if (!invitee) {
+						throw new Error("No invitee defined");
+					}
+					const res = await client2.acceptInvitation({
+						invitationId: invitation.id,
+						name: invitee.name,
+						email: invitee.email,
+						password: invitee.password,
+						additionalFields: {
+							newField: "new-field",
+						},
+					});
+					if (action === "accept-invitation") {
+						expect(res.data?.user.email).toBe(invitee.email);
+					}
+					if (action === "accept-invitation-expect-error") {
+						expect(res.error?.message).toBe(
+							APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST,
+						);
+					}
+					break;
+				}
+				case "reject-invitation": {
+					const res = await client2.rejectInvitation({
+						invitationId: invitation.id,
+					});
+					expect(res.error?.code).toBe("THIS_APP_INVITATION_CANT_BE_REJECTED");
+					break;
+				}
+			}
+		});
+	});
+
+	it("should allow canceling an invitation issued by the user", async () => {
+		const newUser = {
+			email: "test4@test.com",
+		};
+		const invite = await client2.inviteUser({
+			type: "personal",
+			email: newUser.email,
+			additionalFields: {
+				newInviteField: "",
+			},
+			fetchOptions: {
+				headers: user.headers,
+			},
+		});
+		if (!invite.data) {
+			throw new Error("Invitation not created");
+		}
+		expect(invite.data.email).toBe(newUser.email);
+
+		const res = await client2.cancelInvitation({
+			invitationId: invite.data.id,
+			fetchOptions: {
+				headers: user.headers,
+			},
+		});
+		if (!res.data) {
+			throw new Error("Invitation not canceled");
+		}
+		expect(res.data.status).toBe("canceled");
+	});
+
+	it("should not allow canceling an invitation issued by another user", async () => {
+		const isUserSignedUp = await client2.signUp.email({
+			email: "test5@test.com",
+			name: "Test Name",
+			password: "password123456",
+		});
+		if (isUserSignedUp.error) {
+			throw new Error("Could't create test user");
+		}
+		const anotherUser = await signInWithUser("test5@test.com", "password123456");
+
+		const newUser = {
+			email: "test6@test.com",
+		};
+		const invite = await client2.inviteUser({
+			type: "personal",
+			email: newUser.email,
+			additionalFields: {
+				newInviteField: "",
+			},
+			fetchOptions: {
+				headers: user.headers,
+			},
+		});
+		if (!invite.data) {
+			throw new Error("Invitation not created");
+		}
+		expect(invite.data.email).toBe(newUser.email);
+
+		const res = await client2.cancelInvitation({
+			invitationId: invite.data.id,
+			fetchOptions: {
+				headers: anotherUser.headers,
+			},
+		});
+		expect(res.error?.status).toBe(403);
+	});
+
+	it("should allow disabling sending invitations based on the issuer", async () => {
+		const isUserSignedUp = await client2.signUp.email({
+			email: "test7@test.com",
+			name: "Test Name",
+			password: "password123456",
+		});
+		if (isUserSignedUp.error) {
+			throw new Error("Could't create test user");
+		}
+		const anotherUser = await signInWithUser("test7@test.com", "password123456");
+		const res = await client2.inviteUser({
+			type: "personal",
+			email: "test8@test.com",
+			additionalFields: {
+				newInviteField: "",
+			},
+			fetchOptions: {
+				headers: anotherUser.headers,
+			},
+		});
+		expect(res.error?.status).toBe(403);
+	});
+
+	it("should allow listing invitations issued by the user", async () => {
+		const res = await client2.listInvitations({
+			query: {
+				limit: 2,
+			},
+			fetchOptions: {
+				headers: user.headers,
+			},
+		});
+		expect(res.data?.invitations.length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/packages/plugins/app-invite/src/client.ts
+++ b/packages/plugins/app-invite/src/client.ts
@@ -1,0 +1,72 @@
+import type { appInvite } from ".";
+import type { BetterAuthClientPlugin, BetterAuthOptions, BetterAuthPlugin } from "better-auth";
+import type { AppInvitation } from "./schema";
+import type { FieldAttribute } from "better-auth/db";
+import type { AppInviteOptions } from "./types";
+
+export const appInviteClient = <
+	O extends {
+		schema?: {
+			appInvitation?: {
+				additionalFields?: {
+					[key in string]: FieldAttribute;
+				};
+			};
+			user?: {
+				additionalFields?: {
+					[key in string]: FieldAttribute;
+				};
+			};
+		};
+	},
+>(
+	options?: O,
+) => {
+	return {
+		id: "app-invite",
+		$InferServerPlugin: {} as ReturnType<typeof appInvite<O, false>>,
+		getActions: () => ({
+			$Infer: {
+				AppInvitation: {} as AppInvitation,
+			},
+		}),
+		pathMethods: {
+			"/invite-user": "POST",
+			"/accept-invitation": "POST",
+			"/reject-invitation": "POST",
+			"/cancel-invitation": "POST",
+		},
+	} satisfies BetterAuthClientPlugin;
+};
+
+export const inferAppInviteAdditonalFields = <
+	O extends {
+		options: BetterAuthOptions;
+	},
+	S extends AppInviteOptions["schema"] = undefined,
+>(
+	schema?: S,
+) => {
+	type FindById<T extends readonly BetterAuthPlugin[], TargetId extends string> = Extract<
+		T[number],
+		{ id: TargetId }
+	>;
+	type Auth = O extends { options: any } ? O : { options: { plugins: [] } };
+
+	type AppInvitePlugin = FindById<
+		// @ts-expect-error
+		Auth["options"]["plugins"],
+		"app-invite"
+	>;
+	type Schema = O extends Object
+		? O extends Exclude<AppInviteOptions["schema"], undefined>
+			? O
+			: AppInvitePlugin extends { options: { schema: infer S } }
+				? S extends AppInviteOptions["schema"]
+					? S
+					: undefined
+				: undefined
+		: undefined;
+
+	return {} as undefined extends S ? Schema : S;
+};

--- a/packages/plugins/app-invite/src/client.ts
+++ b/packages/plugins/app-invite/src/client.ts
@@ -1,5 +1,9 @@
 import type { appInvite } from ".";
-import type { BetterAuthClientPlugin, BetterAuthOptions, BetterAuthPlugin } from "better-auth";
+import type {
+	BetterAuthClientPlugin,
+	BetterAuthOptions,
+	BetterAuthPlugin,
+} from "better-auth";
 import type { AppInvitation } from "./schema";
 import type { FieldAttribute } from "better-auth/db";
 import type { AppInviteOptions } from "./types";
@@ -47,10 +51,10 @@ export const inferAppInviteAdditonalFields = <
 >(
 	schema?: S,
 ) => {
-	type FindById<T extends readonly BetterAuthPlugin[], TargetId extends string> = Extract<
-		T[number],
-		{ id: TargetId }
-	>;
+	type FindById<
+		T extends readonly BetterAuthPlugin[],
+		TargetId extends string,
+	> = Extract<T[number], { id: TargetId }>;
 	type Auth = O extends { options: any } ? O : { options: { plugins: [] } };
 
 	type AppInvitePlugin = FindById<

--- a/packages/plugins/app-invite/src/client.ts
+++ b/packages/plugins/app-invite/src/client.ts
@@ -43,7 +43,7 @@ export const appInviteClient = <
 	} satisfies BetterAuthClientPlugin;
 };
 
-export const inferAppInviteAdditonalFields = <
+export const inferAppInviteAdditionalFields = <
 	O extends {
 		options: BetterAuthOptions;
 	},

--- a/packages/plugins/app-invite/src/error-codes.ts
+++ b/packages/plugins/app-invite/src/error-codes.ts
@@ -1,6 +1,8 @@
 export const APP_INVITE_ERROR_CODES = {
-	USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION: "User is already a member of this application",
-	USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION: "User was already invited to this application",
+	USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION:
+		"User is already a member of this application",
+	USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION:
+		"User was already invited to this application",
 	INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
 		"Inviter is no longer a member of this application",
 	APP_INVITATION_NOT_FOUND: "App invitation not found",
@@ -36,5 +38,6 @@ export const BASE_ERROR_CODES = {
 	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
 	FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
 	ACCOUNT_NOT_FOUND: "Account not found",
-	USER_ALREADY_HAS_PASSWORD: "User already has a password. Provide that to delete the account.",
+	USER_ALREADY_HAS_PASSWORD:
+		"User already has a password. Provide that to delete the account.",
 };

--- a/packages/plugins/app-invite/src/error-codes.ts
+++ b/packages/plugins/app-invite/src/error-codes.ts
@@ -1,0 +1,40 @@
+export const APP_INVITE_ERROR_CODES = {
+	USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION: "User is already a member of this application",
+	USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION: "User was already invited to this application",
+	INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
+		"Inviter is no longer a member of this application",
+	APP_INVITATION_NOT_FOUND: "App invitation not found",
+	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION:
+		"You are not allowed to cancel this app invitation",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION:
+		"You are not allowed to invite users to this application",
+	THIS_APP_INVITATION_CANT_BE_REJECTED: "This app invitation can't be rejected",
+	EMAIL_DOMAIN_IS_NOT_IN_WHITELIST: "Email domain is not in whitelist",
+} as const;
+
+export const BASE_ERROR_CODES = {
+	USER_NOT_FOUND: "User not found",
+	FAILED_TO_CREATE_USER: "Failed to create user",
+	FAILED_TO_CREATE_SESSION: "Failed to create session",
+	FAILED_TO_UPDATE_USER: "Failed to update user",
+	FAILED_TO_GET_SESSION: "Failed to get session",
+	INVALID_PASSWORD: "Invalid password",
+	INVALID_EMAIL: "Invalid email",
+	INVALID_EMAIL_OR_PASSWORD: "Invalid email or password",
+	SOCIAL_ACCOUNT_ALREADY_LINKED: "Social account already linked",
+	PROVIDER_NOT_FOUND: "Provider not found",
+	INVALID_TOKEN: "invalid token",
+	ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
+	FAILED_TO_GET_USER_INFO: "Failed to get user info",
+	USER_EMAIL_NOT_FOUND: "User email not found",
+	EMAIL_NOT_VERIFIED: "Email not verified",
+	PASSWORD_TOO_SHORT: "Password too short",
+	PASSWORD_TOO_LONG: "Password too long",
+	USER_ALREADY_EXISTS: "User already exists",
+	EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
+	CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
+	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
+	FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
+	ACCOUNT_NOT_FOUND: "Account not found",
+	USER_ALREADY_HAS_PASSWORD: "User already has a password. Provide that to delete the account.",
+};

--- a/packages/plugins/app-invite/src/index.ts
+++ b/packages/plugins/app-invite/src/index.ts
@@ -1,0 +1,110 @@
+import type { BetterAuthPlugin } from "better-auth";
+import type { AppInviteOptions } from "./types";
+import { APP_INVITE_ERROR_CODES } from "./error-codes";
+import type { AppInvitation } from "./schema";
+import {
+	createAppInvitation,
+	getAppInvitation,
+	acceptAppInvitation,
+	rejectAppInvitation,
+	cancelAppInvitation,
+	listAppInvitations,
+} from "./routes";
+import { getAdditionalFields } from "./utils";
+
+export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(opts?: O) => {
+	const options = {
+		canCreateInvitation: true,
+		canCancelInvitation(ctx, invite) {
+			return invite.inviterId === ctx.context.session?.user.id;
+		},
+		cleanupExpiredInvitations: true,
+		cleanupPersonalInvitesOnDecision: false,
+		verifyEmailOnAccept: true,
+		rateLimit: {
+			window: 60,
+			max: 5,
+		},
+		...opts,
+	} satisfies AppInviteOptions;
+
+	const additionalFields = getAdditionalFields(options as O, false);
+
+	const endpoints = {
+		createAppInvitation: createAppInvitation<O, typeof additionalFields, S>(
+			options as O,
+			additionalFields,
+		),
+		getAppInvitation: getAppInvitation(options as O, additionalFields),
+		acceptAppInvitation: acceptAppInvitation(options as O, additionalFields),
+		rejectAppInvitation: rejectAppInvitation(options as O, additionalFields),
+		cancelAppInvitation: cancelAppInvitation(options as O, additionalFields),
+		listAppInvitations: listAppInvitations(options as O, additionalFields),
+	};
+	const endpointPaths = Object.values(endpoints).map((e) => e.path);
+
+	return {
+		id: "app-invite",
+		endpoints,
+		rateLimit: [
+			{
+				pathMatcher(path) {
+					return endpointPaths.some((e) => path.startsWith(e));
+				},
+				...options.rateLimit,
+			},
+		],
+		schema: {
+			appInvitation: {
+				modelName: options.schema?.appInvitation?.modelName,
+				fields: {
+					inviterId: {
+						fieldName: options.schema?.appInvitation?.fields?.inviterId,
+						type: "string",
+						required: true,
+						references: {
+							model: "user",
+							field: "id",
+						},
+					},
+					name: {
+						fieldName: options.schema?.appInvitation?.fields?.name,
+						type: "string",
+						required: false,
+						input: true,
+					},
+					email: {
+						fieldName: options.schema?.appInvitation?.fields?.email,
+						type: "string",
+						required: false,
+						input: true,
+					},
+					status: {
+						fieldName: options.schema?.appInvitation?.fields?.status,
+						type: ["pending", "accepted", "rejected", "canceled"] as const,
+						required: true,
+						defaultValue: "pending",
+					},
+					expiresAt: {
+						fieldName: options.schema?.appInvitation?.fields?.expiresAt,
+						type: "date",
+						required: false,
+					},
+					domainWhitelist: {
+						fieldName: options.schema?.appInvitation?.fields?.domainWhitelist,
+						type: "string",
+						required: false,
+					},
+					...(options.schema?.appInvitation?.additionalFields || {}),
+				},
+			},
+		},
+		$Infer: {
+			AppInvitation: {} as AppInvitation & typeof additionalFields.$ReturnAdditionalFields,
+		},
+		$ERROR_CODES: APP_INVITE_ERROR_CODES,
+	} satisfies BetterAuthPlugin;
+};
+
+export * from "./types";
+export * from "./client";

--- a/packages/plugins/app-invite/src/index.ts
+++ b/packages/plugins/app-invite/src/index.ts
@@ -83,7 +83,13 @@ export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(
 					},
 					status: {
 						fieldName: options.schema?.appInvitation?.fields?.status,
-						type: ["pending", "accepted", "rejected", "canceled", "expired"] as const,
+						type: [
+							"pending",
+							"accepted",
+							"rejected",
+							"canceled",
+							"expired",
+						] as const,
 						required: true,
 						defaultValue: "pending",
 					},

--- a/packages/plugins/app-invite/src/index.ts
+++ b/packages/plugins/app-invite/src/index.ts
@@ -12,7 +12,9 @@ import {
 } from "./routes";
 import { getAdditionalFields } from "./utils";
 
-export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(opts?: O) => {
+export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(
+	opts?: O,
+) => {
 	const options = {
 		canCreateInvitation: true,
 		canCancelInvitation(ctx, invite) {
@@ -100,7 +102,8 @@ export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(
 			},
 		},
 		$Infer: {
-			AppInvitation: {} as AppInvitation & typeof additionalFields.$ReturnAdditionalFields,
+			AppInvitation: {} as AppInvitation &
+				typeof additionalFields.$ReturnAdditionalFields,
 		},
 		$ERROR_CODES: APP_INVITE_ERROR_CODES,
 	} satisfies BetterAuthPlugin;

--- a/packages/plugins/app-invite/src/index.ts
+++ b/packages/plugins/app-invite/src/index.ts
@@ -83,7 +83,7 @@ export const appInvite = <O extends AppInviteOptions, S extends boolean = true>(
 					},
 					status: {
 						fieldName: options.schema?.appInvitation?.fields?.status,
-						type: ["pending", "accepted", "rejected", "canceled"] as const,
+						type: ["pending", "accepted", "rejected", "canceled", "expired"] as const,
 						required: true,
 						defaultValue: "pending",
 					},

--- a/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
@@ -108,6 +108,11 @@ export const acceptAppInvitation = <
 											type: "string",
 											description: "The email address of the user",
 										},
+										resend: {
+											type: "boolean",
+											description:
+												"Resend an invitation if the user was alreay invited.",
+										},
 										password: {
 											type: "string",
 											description: "The password of the user",

--- a/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
@@ -1,0 +1,371 @@
+import { createAuthEndpoint } from "better-auth/plugins";
+import type { AppInviteOptions } from "../types";
+import { z } from "zod";
+import { type InferFieldsInput, parseUserInput, toZodSchema } from "better-auth/db";
+import { getAppInviteAdapter } from "../adapter";
+import type { getAdditionalFields } from "../utils";
+import { APIError, createEmailVerificationToken, originCheck } from "better-auth/api";
+import { BASE_ERROR_CODES, APP_INVITE_ERROR_CODES } from "../error-codes";
+import type { User } from "better-auth";
+import type { AppInvitation } from "../schema";
+import { setSessionCookie } from "better-auth/cookies";
+import { isDevelopment } from "@better-auth-extended/internal-env";
+import { matchWildcard, type IsExactlyEmptyObject } from "@better-auth-extended/internal-utils";
+
+export const acceptAppInvitation = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+>(
+	options: O,
+	{ $ReturnAdditionalFields }: A,
+) => {
+	type AdditionalFields = O["schema"] extends {
+		user: {
+			additionalFields: infer Field;
+		};
+	}
+		? InferFieldsInput<Field>
+		: {};
+
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/accept-invitation",
+		{
+			method: "POST",
+			query: z
+				.object({
+					callbackURL: z
+						.string()
+						.meta({
+							description: "The URL to redirect to after accepting the invitation",
+						})
+						.optional(),
+				})
+				.optional(),
+			body: z.object({
+				invitationId: z.string().meta({
+					description: "The ID of the invitation",
+				}),
+				name: z.string().optional(),
+				email: z.email().optional(),
+				password: z.string(),
+				additionalFields: z
+					.object({
+						...(options.schema?.user?.additionalFields
+							? toZodSchema({
+									fields: options.schema?.user?.additionalFields,
+									isClientSide: true,
+								}).shape
+							: {}),
+					})
+					.optional(),
+			}),
+			use: [originCheck((ctx) => ctx.query?.callbackURL)],
+			metadata: {
+				$Infer: {
+					body: {} as {
+						invitationId: string;
+
+						name?: string;
+						email?: string;
+						password: string;
+					} & (IsExactlyEmptyObject<AdditionalFields> extends true
+						? { additionalFields?: {} }
+						: { additionalFields: AdditionalFields }),
+				},
+				openapi: {
+					operationId: "acceptAppInvitation",
+					description: "Accept an app invitation that has been issued by another user",
+					requestBody: {
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										invitationId: {
+											type: "string",
+											description: "The ID of the invitation",
+										},
+										name: {
+											type: "string",
+											description: "The name of the user",
+										},
+										email: {
+											type: "string",
+											description: "The email address of the user",
+										},
+										password: {
+											type: "string",
+											description: "The password of the user",
+										},
+									},
+									required: ["invitationId", "password"],
+								},
+							},
+						},
+					},
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											token: {
+												type: "string",
+											},
+											invitation: {
+												$ref: "#/components/schemas/AppInvitation",
+											},
+											user: {
+												$ref: "#/components/schemas/User",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			if (ctx.context.session?.session) {
+				throw new APIError("FORBIDDEN");
+			}
+
+			const adapter = getAppInviteAdapter(ctx.context, options);
+
+			const invitation = await adapter.findInvitationById(ctx.body.invitationId, {
+				where: [
+					{
+						field: "status",
+						value: "pending",
+					},
+				],
+			});
+			const isExpired = invitation?.expiresAt ? invitation?.expiresAt < new Date() : false;
+			if (!invitation || isExpired) {
+				if (isExpired && options.cleanupExpiredInvitations && invitation) {
+					await adapter.deleteInvitation(invitation.id);
+				}
+				throw new APIError("BAD_REQUEST", {
+					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				});
+			}
+
+			const invitationType = invitation.email ? "personal" : "public";
+
+			const inviter = await ctx.context.internalAdapter.findUserById(invitation.inviterId);
+			if (!inviter) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
+				});
+			}
+
+			let userData = {
+				name: invitation.name || ctx.body.name,
+				email: invitation.email || ctx.body.email,
+				...ctx.body.additionalFields,
+			} as User & Record<string, any>;
+
+			const dbUser = await ctx.context.internalAdapter.findUserByEmail(userData.email);
+			if (dbUser?.user) {
+				ctx.context.logger.info(`Sign-up attempt for existing email: ${userData.email}`);
+				throw new APIError("UNPROCESSABLE_ENTITY", {
+					message: BASE_ERROR_CODES.USER_ALREADY_EXISTS,
+				});
+			}
+
+			const before = await options.hooks?.accept?.before?.(ctx, userData);
+			if (before?.user) {
+				userData = before.user;
+			}
+			const isValidEmail = z.email().safeParse(userData.email);
+
+			if (!isValidEmail.success) {
+				throw new APIError("BAD_REQUEST", {
+					message: BASE_ERROR_CODES.INVALID_EMAIL,
+				});
+			}
+
+			if (invitationType === "public") {
+				const [_lP, domain] = userData.email.split("@");
+
+				const domainWhitelist = invitation.domainWhitelist?.split(",");
+
+				const isMatch = matchWildcard(domain.trim().toLowerCase(), ".");
+				if (
+					domainWhitelist?.length &&
+					domainWhitelist.length > 0 &&
+					!domainWhitelist.some((wDomain: string) =>
+						isMatch(wDomain.trim().toLowerCase()),
+					)
+				) {
+					throw new APIError("FORBIDDEN", {
+						message: APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST,
+					});
+				}
+			}
+
+			const minPasswordLength = ctx.context.password.config.minPasswordLength;
+			if (ctx.body.password.length < minPasswordLength) {
+				ctx.context.logger.error("Password is too short");
+				throw new APIError("BAD_REQUEST", {
+					message: BASE_ERROR_CODES.PASSWORD_TOO_SHORT,
+				});
+			}
+			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
+			if (ctx.body.password.length > maxPasswordLength) {
+				ctx.context.logger.error("Password is too long");
+				throw new APIError("BAD_REQUEST", {
+					message: BASE_ERROR_CODES.PASSWORD_TOO_LONG,
+				});
+			}
+
+			const additionalData = parseUserInput(ctx.context.options, ctx.body.additionalFields);
+			const hash = await ctx.context.password.hash(ctx.body.password);
+			let createdUser: User;
+			try {
+				createdUser = await ctx.context.internalAdapter.createUser({
+					email: userData.email.toLowerCase(),
+					name: userData.name,
+					...additionalData,
+					emailVerified: options.verifyEmailOnAccept,
+				});
+				if (!createdUser) {
+					throw new APIError("UNPROCESSABLE_ENTITY", {
+						message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+					});
+				}
+			} catch (e) {
+				if (isDevelopment) {
+					ctx.context.logger.error("Failed to create user", e);
+				}
+				if (e instanceof APIError) {
+					throw e;
+				}
+				throw new APIError("UNPROCESSABLE_ENTITY", {
+					message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+					details: e,
+				});
+			}
+			if (!createdUser) {
+				throw new APIError("UNPROCESSABLE_ENTITY", {
+					message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+				});
+			}
+
+			await ctx.context.internalAdapter.linkAccount(
+				{
+					userId: createdUser.id,
+					providerId: "credential",
+					accountId: createdUser.id,
+					password: hash,
+				},
+				ctx,
+			);
+
+			let acceptedI: AppInvitation | null = invitation;
+			if (invitationType === "personal") {
+				if (options.cleanupPersonalInvitesOnDecision) {
+					await adapter.deleteInvitation(invitation.id);
+				} else {
+					acceptedI = await adapter.updateInvitation(invitation.id, "accepted");
+				}
+			}
+
+			await options.hooks?.accept?.after?.(ctx, {
+				invitation: acceptedI!,
+				user: createdUser,
+			});
+
+			if (!options.verifyEmailOnAccept) {
+				if (
+					ctx.context.options.emailVerification?.sendOnSignUp ||
+					ctx.context.options.emailAndPassword?.requireEmailVerification
+				) {
+					const token = await createEmailVerificationToken(
+						ctx.context.secret,
+						createdUser.email,
+						undefined,
+						ctx.context.options.emailVerification?.expiresIn,
+					);
+					const url = `${
+						ctx.context.baseURL
+					}/verify-email?token=${token}&callbackURL=${ctx.query?.callbackURL || "/"}`;
+					await ctx.context.options.emailVerification?.sendVerificationEmail?.(
+						{
+							user: createdUser,
+							url,
+							token,
+						},
+						ctx.request,
+					);
+				}
+
+				if (ctx.context.options.emailAndPassword?.requireEmailVerification) {
+					return ctx.json({
+						token: null,
+						user: {
+							id: createdUser.id,
+							email: createdUser.email,
+							name: createdUser.name,
+							image: createdUser.image,
+							emailVerified: createdUser.emailVerified,
+							createdAt: createdUser.createdAt,
+							updatedAt: createdUser.updatedAt,
+						},
+						invitation: acceptedI as (AppInvitation & ReturnAdditionalFields) | null,
+					});
+				}
+			}
+
+			if (!options?.autoSignIn) {
+				return ctx.json({
+					token: null,
+					user: {
+						id: createdUser.id,
+						email: createdUser.email,
+						name: createdUser.name,
+						image: createdUser.image,
+						emailVerified: createdUser.emailVerified,
+						createdAt: createdUser.createdAt,
+						updatedAt: createdUser.updatedAt,
+					},
+					invitation: acceptedI as (AppInvitation & ReturnAdditionalFields) | null,
+				});
+			}
+
+			const session = await ctx.context.internalAdapter.createSession(createdUser.id, ctx);
+			if (!session) {
+				throw new APIError("BAD_REQUEST", {
+					message: BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
+				});
+			}
+			await setSessionCookie(ctx, {
+				session,
+				user: createdUser,
+			});
+			if (!ctx.query?.callbackURL) {
+				return ctx.json({
+					token: session.token,
+					user: {
+						id: createdUser.id,
+						email: createdUser.email,
+						name: createdUser.name,
+						image: createdUser.image,
+						emailVerified: createdUser.emailVerified,
+						createdAt: createdUser.createdAt,
+						updatedAt: createdUser.updatedAt,
+					},
+					invitation: acceptedI as (AppInvitation & ReturnAdditionalFields) | null,
+				});
+			}
+			throw ctx.redirect(ctx.query.callbackURL);
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -29,6 +29,21 @@ export const cancelAppInvitation = <
 			metadata: {
 				operationId: "cancelAppInvitation",
 				description: "Cancel an app invitation",
+				requestBody: {
+					content: {
+						"application/json": {
+							schema: {
+								type: "object",
+								properties: {
+									invitationId: {
+										type: "string",
+									},
+								},
+								required: ["invitationId"],
+							},
+						},
+					},
+				},
 				responses: {
 					"200": {
 						description: "Success",
@@ -88,6 +103,13 @@ export const cancelAppInvitation = <
 					"canceled",
 				);
 			}
+
+			canceledI = canceledI
+				? {
+						...canceledI,
+						status: "canceled",
+					}
+				: null;
 
 			await options.hooks?.cancel?.after?.(ctx, canceledI!);
 

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -1,0 +1,97 @@
+import { APIError, sessionMiddleware } from "better-auth/api";
+import { createAuthEndpoint } from "better-auth/plugins";
+import { z } from "zod";
+import type { AppInviteOptions } from "../types";
+import { getAppInviteAdapter } from "../adapter";
+import { APP_INVITE_ERROR_CODES } from "../error-codes";
+import type { getAdditionalFields } from "../utils";
+import type { AppInvitation } from "../schema";
+
+export const cancelAppInvitation = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+>(
+	options: O,
+	{ $ReturnAdditionalFields }: A,
+) => {
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/cancel-invitation",
+		{
+			method: "POST",
+			body: z.object({
+				invitationId: z.string().meta({
+					description: "The ID of the app invitation to cancel",
+				}),
+			}),
+			use: [sessionMiddleware],
+			metadata: {
+				operationId: "cancelAppInvitation",
+				description: "Cancel an app invitation",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									$ref: "#/components/schemas/AppInvitation",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const adapter = getAppInviteAdapter(ctx.context, options);
+			const invitation = await adapter.findInvitationById(
+				ctx.body.invitationId,
+				{
+					where: [
+						{
+							field: "status",
+							value: "pending",
+						},
+					],
+				},
+			);
+			if (!invitation) {
+				throw new APIError("BAD_REQUEST", {
+					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				});
+			}
+			const canCancel = options.allowUserToCancelInvitation
+				? await options.allowUserToCancelInvitation({
+						user: session.user,
+						invitation,
+					})
+				: typeof options.canCancelInvitation === "function"
+					? await options.canCancelInvitation(ctx, invitation)
+					: options.canCancelInvitation;
+			if (!canCancel) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION,
+				});
+			}
+
+			await options.hooks?.cancel?.before?.(ctx, invitation);
+
+			let canceledI: AppInvitation | null = invitation;
+			if (options.cleanupPersonalInvitesOnDecision) {
+				await adapter.deleteInvitation(invitation.id);
+			} else {
+				canceledI = await adapter.updateInvitation<ReturnAdditionalFields>(
+					invitation.id,
+					"canceled",
+				);
+			}
+
+			await options.hooks?.cancel?.after?.(ctx, canceledI!);
+
+			return ctx.json(canceledI as (AppInvitation & ReturnAdditionalFields) | null);
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -111,7 +111,11 @@ export const cancelAppInvitation = <
 					}
 				: null;
 
-			await options.hooks?.cancel?.after?.(ctx, canceledI!);
+			if (!canceledI) {
+				throw ctx.error("INTERNAL_SERVER_ERROR");
+			}
+
+			await options.hooks?.cancel?.after?.(ctx, canceledI);
 
 			return ctx.json(
 				canceledI as (AppInvitation & ReturnAdditionalFields) | null,

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -91,7 +91,9 @@ export const cancelAppInvitation = <
 
 			await options.hooks?.cancel?.after?.(ctx, canceledI!);
 
-			return ctx.json(canceledI as (AppInvitation & ReturnAdditionalFields) | null);
+			return ctx.json(
+				canceledI as (AppInvitation & ReturnAdditionalFields) | null,
+			);
 		},
 	);
 };

--- a/packages/plugins/app-invite/src/routes/create-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/create-app-invitation.ts
@@ -6,7 +6,10 @@ import { getAppInviteAdapter } from "../adapter";
 import { type CreateInvitation, createInvitationSchema } from "../schema";
 import { z } from "zod";
 import type { getAdditionalFields } from "../utils";
-import type { IsExactlyEmptyObject, Merge } from "@better-auth-extended/internal-utils";
+import type {
+	IsExactlyEmptyObject,
+	Merge,
+} from "@better-auth-extended/internal-utils";
 
 export const createAppInvitation = <
 	O extends AppInviteOptions,
@@ -26,12 +29,16 @@ export const createAppInvitation = <
 			use: [sessionMiddleware],
 			body: createInvitationSchema.and(
 				z.object({
-					additionalFields: z.object({ ...additionalFieldsSchema.shape }).optional(),
+					additionalFields: z
+						.object({ ...additionalFieldsSchema.shape })
+						.optional(),
 				}),
 			),
 			metadata: {
 				$Infer: {
-					body: {} as (S extends true ? CreateInvitation : Merge<CreateInvitation>) &
+					body: {} as (S extends true
+						? CreateInvitation
+						: Merge<CreateInvitation>) &
 						(IsExactlyEmptyObject<AdditionalFields> extends true
 							? { additionalFields?: {} }
 							: { additionalFields: AdditionalFields }),
@@ -67,7 +74,10 @@ export const createAppInvitation = <
 			const session = ctx.context.session;
 			const canInvite = options.allowUserToCreateInvitation
 				? typeof options.allowUserToCreateInvitation === "function"
-					? await options.allowUserToCreateInvitation(session.user, ctx.body.type)
+					? await options.allowUserToCreateInvitation(
+							session.user,
+							ctx.body.type,
+						)
 					: options.allowUserToCreateInvitation
 				: ((typeof options.canCreateInvitation === "function"
 						? await options.canCreateInvitation(ctx)
@@ -96,14 +106,17 @@ export const createAppInvitation = <
 							APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION,
 					});
 				}
-				const alreadyInvited = await adapter.findInvitationByEmail(ctx.body.email, {
-					where: [
-						{
-							field: "status",
-							value: "pending",
-						},
-					],
-				});
+				const alreadyInvited = await adapter.findInvitationByEmail(
+					ctx.body.email,
+					{
+						where: [
+							{
+								field: "status",
+								value: "pending",
+							},
+						],
+					},
+				);
 				if (alreadyInvited && !ctx.body.resend) {
 					throw new APIError("BAD_REQUEST", {
 						message:

--- a/packages/plugins/app-invite/src/routes/create-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/create-app-invitation.ts
@@ -1,0 +1,138 @@
+import { APIError, sessionMiddleware } from "better-auth/api";
+import { createAuthEndpoint } from "better-auth/plugins";
+import type { AppInviteOptions } from "../types";
+import { APP_INVITE_ERROR_CODES } from "../error-codes";
+import { getAppInviteAdapter } from "../adapter";
+import { type CreateInvitation, createInvitationSchema } from "../schema";
+import { z } from "zod";
+import type { getAdditionalFields } from "../utils";
+import type { IsExactlyEmptyObject, Merge } from "@better-auth-extended/internal-utils";
+
+export const createAppInvitation = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+	S extends boolean,
+>(
+	options: O,
+	{ additionalFieldsSchema, $AdditionalFields, $ReturnAdditionalFields }: A,
+) => {
+	type AdditionalFields = typeof $AdditionalFields;
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/invite-user",
+		{
+			method: "POST",
+			use: [sessionMiddleware],
+			body: createInvitationSchema.and(
+				z.object({
+					additionalFields: z.object({ ...additionalFieldsSchema.shape }).optional(),
+				}),
+			),
+			metadata: {
+				$Infer: {
+					body: {} as (S extends true ? CreateInvitation : Merge<CreateInvitation>) &
+						(IsExactlyEmptyObject<AdditionalFields> extends true
+							? { additionalFields?: {} }
+							: { additionalFields: AdditionalFields }),
+				},
+				openapi: {
+					operationId: "createAppInvitation",
+					description: "Invite a user to the app",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										$ref: "#/components/schemas/AppInvitation",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			if (ctx.body.type === "personal" && !options.sendInvitationEmail) {
+				ctx.context.logger.warn(
+					"Invitation email is not enabled. Pass `sendInvitationEmail` to the plugin options to enable it.",
+				);
+				throw new APIError("BAD_REQUEST", {
+					message: "Invitation email is not enabled",
+				});
+			}
+
+			const session = ctx.context.session;
+			const canInvite = options.allowUserToCreateInvitation
+				? typeof options.allowUserToCreateInvitation === "function"
+					? await options.allowUserToCreateInvitation(session.user, ctx.body.type)
+					: options.allowUserToCreateInvitation
+				: ((typeof options.canCreateInvitation === "function"
+						? await options.canCreateInvitation(ctx)
+						: options.canCreateInvitation) ?? true);
+
+			if (!canInvite) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION,
+				});
+			}
+
+			const adapter = getAppInviteAdapter(ctx.context, options);
+			if (ctx.body.type === "personal") {
+				if (!ctx.body.email) {
+					throw new APIError("BAD_REQUEST", {
+						message: "Missing required field.",
+					});
+				}
+				const alreadyMember = await ctx.context.internalAdapter.findUserByEmail(
+					ctx.body.email,
+				);
+				if (alreadyMember) {
+					throw new APIError("BAD_REQUEST", {
+						message:
+							APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION,
+					});
+				}
+				const alreadyInvited = await adapter.findInvitationByEmail(ctx.body.email, {
+					where: [
+						{
+							field: "status",
+							value: "pending",
+						},
+					],
+				});
+				if (alreadyInvited && !ctx.body.resend) {
+					throw new APIError("BAD_REQUEST", {
+						message:
+							APP_INVITE_ERROR_CODES.USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION,
+					});
+				}
+			}
+
+			await options.hooks?.create?.before?.(ctx);
+
+			const invitation = await adapter.createInvitation<ReturnAdditionalFields>(
+				ctx.body,
+				session.user,
+			);
+
+			if (invitation.email && ctx.body.type === "personal") {
+				await options.sendInvitationEmail?.(
+					{
+						...invitation,
+						type: ctx.body.type,
+						inviter: session.user,
+					},
+					ctx.request,
+				);
+			}
+
+			await options.hooks?.create?.after?.(ctx, invitation);
+
+			return invitation;
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -65,8 +65,12 @@ export const getAppInvitation = <
 				? invitation?.expiresAt < new Date()
 				: false;
 			if (!invitation || isExpired) {
-				if (isExpired && options.cleanupExpiredInvitations && invitation) {
-					await adapter.deleteInvitation(invitation.id);
+				if (isExpired && invitation) {
+					if (options.cleanupExpiredInvitations) {
+						await adapter.deleteInvitation(invitation.id);
+					} else {
+						await adapter.updateInvitation(invitation.id, "expired");
+					}
 				}
 				throw new APIError("BAD_REQUEST", {
 					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -3,7 +3,7 @@ import type { getAdditionalFields } from "../utils";
 import type { AppInviteOptions } from "../types";
 import { z } from "zod";
 import { getAppInviteAdapter } from "../adapter";
-import { APIError } from "better-auth";
+import { APIError } from "better-auth/api";
 import { APP_INVITE_ERROR_CODES } from "../error-codes";
 
 export const getAppInvitation = <
@@ -37,10 +37,39 @@ export const getAppInvitation = <
 										$ref: "#/components/schemas/AppInvitation",
 										type: "object",
 										properties: {
-											// TODO:
+											id: {
+												type: "string",
+											},
+											name: {
+												type: "string",
+											},
+											email: {
+												type: "string",
+											},
+											inviterId: {
+												type: "string",
+											},
+											status: {
+												type: "string",
+											},
+											domainWhitelist: {
+												type: "string"
+											},
+											expiresAt: {
+												type: "string",
+											},
+											inviterEmail: {
+												type: "string",
+											},
+											inviterImage: {
+												type: "string",
+											},
 										},
 										required: [
-											// TODO:
+											"id",
+											"inviterId",
+											"inviterEmail",
+											"status",
 										],
 									},
 								},

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -1,0 +1,95 @@
+import { createAuthEndpoint } from "better-auth/plugins";
+import type { getAdditionalFields } from "../utils";
+import type { AppInviteOptions } from "../types";
+import { z } from "zod";
+import { getAppInviteAdapter } from "../adapter";
+import { APIError } from "better-auth";
+import { APP_INVITE_ERROR_CODES } from "../error-codes";
+
+export const getAppInvitation = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+>(
+	options: O,
+	{ $ReturnAdditionalFields }: A,
+) => {
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/get-app-invitation",
+		{
+			method: "GET",
+			query: z.object({
+				id: z.string().meta({
+					description: "The ID of the invitation to get.",
+				}),
+			}),
+			metadata: {
+				openapi: {
+					operationId: "getAppInvitation",
+					description: "Get an invitation by ID",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										$ref: "#/components/schemas/AppInvitation",
+										type: "object",
+										properties: {
+											// TODO:
+										},
+										required: [
+											// TODO:
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const adapter = getAppInviteAdapter(ctx.context, options);
+			const invitation =
+				await adapter.findInvitationById<ReturnAdditionalFields>(ctx.query.id, {
+					where: [
+						{
+							field: "status",
+							value: "pending",
+						},
+					],
+				});
+			const isExpired = invitation?.expiresAt
+				? invitation?.expiresAt < new Date()
+				: false;
+			if (!invitation || isExpired) {
+				if (isExpired && options.cleanupExpiredInvitations && invitation) {
+					await adapter.deleteInvitation(invitation.id);
+				}
+				throw new APIError("BAD_REQUEST", {
+					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				});
+			}
+
+			const inviter = await ctx.context.internalAdapter.findUserById(
+				invitation.inviterId,
+			);
+			if (!inviter) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
+				});
+			}
+
+			const data = {
+				...invitation,
+				inviterEmail: inviter.email,
+				inviterImage: inviter.image,
+			};
+
+			return data;
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -53,7 +53,7 @@ export const getAppInvitation = <
 												type: "string",
 											},
 											domainWhitelist: {
-												type: "string"
+												type: "string",
 											},
 											expiresAt: {
 												type: "string",
@@ -65,12 +65,7 @@ export const getAppInvitation = <
 												type: "string",
 											},
 										},
-										required: [
-											"id",
-											"inviterId",
-											"inviterEmail",
-											"status",
-										],
+										required: ["id", "inviterId", "inviterEmail", "status"],
 									},
 								},
 							},

--- a/packages/plugins/app-invite/src/routes/index.ts
+++ b/packages/plugins/app-invite/src/routes/index.ts
@@ -1,0 +1,6 @@
+export * from "./create-app-invitation";
+export * from "./get-app-invitation";
+export * from "./accept-app-invitation";
+export * from "./reject-app-invitation";
+export * from "./cancel-app-invitation";
+export * from "./list-app-invitations";

--- a/packages/plugins/app-invite/src/routes/list-app-invitations.ts
+++ b/packages/plugins/app-invite/src/routes/list-app-invitations.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+import type { AppInviteOptions } from "../types";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
+import { getAppInviteAdapter } from "../adapter";
+import type { Where } from "better-auth";
+import type { getAdditionalFields } from "../utils";
+
+export const listAppInvitations = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+>(
+	options: O,
+	{ $ReturnAdditionalFields }: A,
+) => {
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/list-invitations",
+		{
+			method: "GET",
+			use: [sessionMiddleware],
+			query: z.object({
+				searchValue: z
+					.string()
+					.meta({
+						description: "The value to search for",
+					})
+					.optional(),
+				searchField: z
+					.enum(["name", "email", "domainWhitelist"])
+					.meta({
+						description:
+							"The field to search in, defaults to email. Can be `email`, `name` or `domainWhitelist`",
+					})
+					.optional(),
+				searchOperator: z
+					.enum(["contains", "starts_with", "ends_with"])
+					.meta({
+						description:
+							"The operator to use for the search. Can be `contains`, `starts_with` or `ends_with`",
+					})
+					.optional(),
+				limit: z.coerce
+					.number()
+					.meta({
+						description: "The numbers of invitations to return",
+					})
+					.optional(),
+				offset: z.coerce
+					.number()
+					.meta({
+						description: "The offset to start from",
+					})
+					.optional(),
+				sortBy: z
+					.string()
+					.meta({
+						description: "The field to sort by",
+					})
+					.optional(),
+				sortDirection: z
+					.enum(["asc", "desc"])
+					.meta({
+						description: "The direction to sort by",
+					})
+					.optional(),
+				filterField: z
+					.string()
+					.meta({
+						description: "The field to filter by",
+					})
+					.optional(),
+				filterValue: z
+					.string()
+					.or(z.number())
+					.or(z.boolean())
+					.meta({
+						description: "The value to filter by",
+					})
+					.optional(),
+				filterOperator: z
+					.enum(["eq", "ne", "lt", "lte", "gt", "gte"])
+					.meta({
+						description: "The operator to use for the filter",
+					})
+					.optional(),
+			}),
+			metadata: {
+				openapi: {
+					operationId: "listAppInvitations",
+					summary: "List issued invitations",
+					description: "List issued invitations",
+					responses: {
+						200: {
+							description: "List of issued invitations",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											invitations: {
+												type: "array",
+												items: {
+													$ref: "#/components/schemas/AppInvitation",
+												},
+											},
+											total: {
+												type: "number",
+											},
+											limit: {
+												type: ["number", "undefined"],
+											},
+											offset: {
+												type: ["number", "undefined"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const where: Where[] = [
+				{
+					field: "inviterId",
+					value: ctx.context.session.user.id,
+				},
+			];
+
+			if (ctx.query?.searchValue) {
+				where.push({
+					field: ctx.query.searchField || "email",
+					operator: ctx.query.searchOperator || "contains",
+					value: ctx.query.searchValue,
+				});
+			}
+
+			if (ctx.query?.filterValue && ctx.query.filterField !== "inviterId") {
+				where.push({
+					field: ctx.query.filterField || "email",
+					operator: ctx.query.filterOperator || "eq",
+					value: ctx.query.filterValue,
+				});
+			}
+
+			const adapter = await getAppInviteAdapter(ctx.context, options);
+
+			try {
+				const limit = Number(ctx.query?.limit) || undefined;
+				const offset = Number(ctx.query?.offset) || undefined;
+
+				const total = await adapter.countInvitations({ where });
+
+				const invitations =
+					await adapter.listInvitations<ReturnAdditionalFields>({
+						where,
+						limit: ctx.query.limit,
+						offset: ctx.query.offset,
+						sortBy: ctx.query.sortBy
+							? {
+									field: ctx.query.sortBy,
+									direction: ctx.query.sortDirection || "asc",
+								}
+							: undefined,
+					});
+
+				return ctx.json({
+					total,
+					invitations,
+					limit,
+					offset,
+				});
+			} catch (e) {
+				return ctx.json({
+					total: 0,
+					invitations: [],
+				});
+			}
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/routes/list-app-invitations.ts
+++ b/packages/plugins/app-invite/src/routes/list-app-invitations.ts
@@ -42,12 +42,14 @@ export const listAppInvitations = <
 					.optional(),
 				limit: z.coerce
 					.number()
+					.int()
 					.meta({
 						description: "The numbers of invitations to return",
 					})
 					.optional(),
 				offset: z.coerce
 					.number()
+					.int()
 					.meta({
 						description: "The offset to start from",
 					})

--- a/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
@@ -71,7 +71,7 @@ export const rejectAppInvitation = <
 												$ref: "#/components/schemas/AppInvitation",
 											},
 											user: {
-												$ref: "#/components/schemas/User",
+												$ref: "null",
 											},
 										},
 									},

--- a/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
@@ -1,0 +1,139 @@
+import { createAuthEndpoint } from "better-auth/plugins";
+import type { AppInviteOptions } from "../types";
+import { z } from "zod";
+import { APIError, originCheck } from "better-auth/api";
+import { getAppInviteAdapter } from "../adapter";
+import { APP_INVITE_ERROR_CODES } from "../error-codes";
+import type { AppInvitation } from "../schema";
+import type { getAdditionalFields } from "../utils";
+
+export const rejectAppInvitation = <
+	O extends AppInviteOptions,
+	A extends ReturnType<typeof getAdditionalFields<O>>,
+>(
+	options: O,
+	{ $ReturnAdditionalFields }: A,
+) => {
+	type ReturnAdditionalFields = typeof $ReturnAdditionalFields;
+
+	return createAuthEndpoint(
+		"/reject-invitation",
+		{
+			method: "POST",
+			query: z
+				.object({
+					callbackURL: z
+						.string()
+						.meta({
+							description:
+								"The URL to redirect to after rejecting the invitation",
+						})
+						.optional(),
+				})
+				.optional(),
+			body: z.object({
+				invitationId: z.string().meta({
+					description: "The ID of the invitation",
+				}),
+			}),
+			use: [originCheck((ctx) => ctx.query?.callbackURL)],
+			metadata: {
+				openapi: {
+					operationId: "rejectAppInvitation",
+					description: "Reject an app invitation",
+					requestBody: {
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										invitationId: {
+											type: "string",
+										},
+									},
+									required: ["invitationId"],
+								},
+							},
+						},
+					},
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											token: {
+												type: "null",
+											},
+											invitation: {
+												$ref: "#/components/schemas/AppInvitation",
+											},
+											user: {
+												$ref: "#/components/schemas/User",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			if (ctx.context.session?.session) {
+				throw new APIError("FORBIDDEN");
+			}
+			const adapter = getAppInviteAdapter(ctx.context, options);
+			const invitation = await adapter.findInvitationById(
+				ctx.body.invitationId,
+				{
+					where: [
+						{
+							field: "status",
+							value: "pending",
+						},
+					],
+				},
+			);
+			const type = !invitation?.email ? "public" : "personal";
+			const isExpired = invitation?.expiresAt
+				? invitation?.expiresAt < new Date()
+				: false;
+			if (!invitation || isExpired) {
+				if (isExpired && options.cleanupExpiredInvitations && invitation) {
+					await adapter.deleteInvitation(invitation.id);
+				}
+				throw new APIError("BAD_REQUEST", {
+					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				});
+			}
+			if (type === "public") {
+				throw new APIError("BAD_REQUEST", {
+					message: APP_INVITE_ERROR_CODES.THIS_APP_INVITATION_CANT_BE_REJECTED,
+				});
+			}
+
+			await options.hooks?.reject?.before?.(ctx, invitation);
+
+			let rejectedI: AppInvitation | null = invitation;
+			if (options.cleanupPersonalInvitesOnDecision) {
+				await adapter.deleteInvitation(invitation.id);
+			} else {
+				rejectedI = await adapter.updateInvitation(invitation.id, "rejected");
+			}
+
+			await options.hooks?.reject?.after?.(ctx, rejectedI!);
+
+			return ctx.json({
+				token: null,
+				invitation: rejectedI as
+					| (AppInvitation & ReturnAdditionalFields)
+					| null,
+				user: null,
+			});
+		},
+	);
+};

--- a/packages/plugins/app-invite/src/schema.ts
+++ b/packages/plugins/app-invite/src/schema.ts
@@ -12,6 +12,7 @@ export const appInvitationSchema = z.object({
 	inviterId: z.string(),
 	expiresAt: z.date().optional(),
 	domainWhitelist: z.string().optional(),
+	createdAt: z.date().default(() => new Date()),
 });
 export type AppInvitation = z.infer<typeof appInvitationSchema>;
 export type AppInvitationInput = z.input<typeof appInvitationSchema>;

--- a/packages/plugins/app-invite/src/schema.ts
+++ b/packages/plugins/app-invite/src/schema.ts
@@ -23,16 +23,19 @@ const createPersonalInvitationSchema = z.object({
 	name: z
 		.string()
 		.meta({
-			description: "The name of the user to invite (Only for personal invitations)",
+			description:
+				"The name of the user to invite (Only for personal invitations)",
 		})
 		.optional(),
 	email: z.string().meta({
-		description: "The email address of the user to invite (Only for personal invitations)",
+		description:
+			"The email address of the user to invite (Only for personal invitations)",
 	}),
 	resend: z
 		.boolean()
 		.meta({
-			description: "Resend the invitation email, if the user is already invited",
+			description:
+				"Resend the invitation email, if the user is already invited",
 		})
 		.optional(),
 });

--- a/packages/plugins/app-invite/src/schema.ts
+++ b/packages/plugins/app-invite/src/schema.ts
@@ -1,0 +1,57 @@
+import { generateId } from "better-auth";
+import { z } from "zod";
+
+export const appInvitationStatus = z
+	.enum(["pending", "accepted", "rejected", "canceled"])
+	.default("pending");
+export const appInvitationSchema = z.object({
+	id: z.string().default(generateId),
+	name: z.string().optional(),
+	email: z.email().optional(),
+	status: appInvitationStatus,
+	inviterId: z.string(),
+	expiresAt: z.date().optional(),
+	domainWhitelist: z.string().optional(),
+});
+export type AppInvitation = z.infer<typeof appInvitationSchema>;
+export type AppInvitationInput = z.input<typeof appInvitationSchema>;
+export type AppInvitationStatus = z.infer<typeof appInvitationStatus>;
+export type AppInvitationStatusInput = z.input<typeof appInvitationStatus>;
+
+const createPersonalInvitationSchema = z.object({
+	type: z.literal("personal"),
+	name: z
+		.string()
+		.meta({
+			description: "The name of the user to invite (Only for personal invitations)",
+		})
+		.optional(),
+	email: z.string().meta({
+		description: "The email address of the user to invite (Only for personal invitations)",
+	}),
+	resend: z
+		.boolean()
+		.meta({
+			description: "Resend the invitation email, if the user is already invited",
+		})
+		.optional(),
+});
+
+const createPublicInvitationSchema = z.object({
+	type: z.literal("public"),
+	domainWhitelist: z
+		.string()
+		.or(z.string().array())
+		.meta({
+			description:
+				"A comma separated list of domains that are allowed to accept the invitation. (Only for public invitations)",
+		})
+		.optional(),
+});
+
+export const createInvitationSchema = z.discriminatedUnion("type", [
+	createPersonalInvitationSchema,
+	createPublicInvitationSchema,
+]);
+
+export type CreateInvitation = z.infer<typeof createInvitationSchema>;

--- a/packages/plugins/app-invite/src/schema.ts
+++ b/packages/plugins/app-invite/src/schema.ts
@@ -2,7 +2,7 @@ import { generateId } from "better-auth";
 import { z } from "zod";
 
 export const appInvitationStatus = z
-	.enum(["pending", "accepted", "rejected", "canceled"])
+	.enum(["pending", "accepted", "rejected", "canceled", "expired"])
 	.default("pending");
 export const appInvitationSchema = z.object({
 	id: z.string().default(generateId),

--- a/packages/plugins/app-invite/src/schema.ts
+++ b/packages/plugins/app-invite/src/schema.ts
@@ -27,7 +27,7 @@ const createPersonalInvitationSchema = z.object({
 				"The name of the user to invite (Only for personal invitations)",
 		})
 		.optional(),
-	email: z.string().meta({
+	email: z.email().meta({
 		description:
 			"The email address of the user to invite (Only for personal invitations)",
 	}),

--- a/packages/plugins/app-invite/src/types.ts
+++ b/packages/plugins/app-invite/src/types.ts
@@ -50,7 +50,9 @@ export type AppInviteOptions = {
 	 * ```
 	 * @default true
 	 */
-	canCreateInvitation?: ((ctx: GenericEndpointContext) => Promise<boolean> | boolean) | boolean;
+	canCreateInvitation?:
+		| ((ctx: GenericEndpointContext) => Promise<boolean> | boolean)
+		| boolean;
 	/**
 	 * Define whether a user is allowed to cancel invitations.
 	 *

--- a/packages/plugins/app-invite/src/types.ts
+++ b/packages/plugins/app-invite/src/types.ts
@@ -1,0 +1,198 @@
+import type { GenericEndpointContext, User } from "better-auth";
+import type { AppInvitation } from "./schema";
+import type { FieldAttribute } from "better-auth/db";
+
+export type AppInvitationType = "personal" | "public";
+
+export type AppInviteOptions = {
+	/**
+	 * Define whether a user is allowed to send invitations.
+	 *
+	 * You can also pass a function that returns a boolean.
+	 *
+	 * 	@example
+	 * ```ts
+	 * allowUserToCreateInvitation: async (user) => {
+	 * 		const canInvite: boolean = await hasPermission(user, 'send-invitation');
+	 *      return canInvite;
+	 * }
+	 * ```
+	 * @deprecated use `canCreateInvitation` instead.
+	 */
+	allowUserToCreateInvitation?:
+		| boolean
+		| ((
+				user: User & Record<string, any>,
+				type: AppInvitationType,
+		  ) => Promise<boolean> | boolean);
+	/**
+	 * Define whether a user is allowed to cancel invitations.
+	 *
+	 * By default users can only cancel invitations issued by themself.
+	 *
+	 * @deprecated use `canCancelInvitation` instead.
+	 */
+	allowUserToCancelInvitation?: (data: {
+		user: User;
+		invitation: AppInvitation;
+	}) => Promise<boolean> | boolean;
+	/**
+	 * Define whether a user is allowed to send invitations.
+	 *
+	 * You can also pass a function that returns a boolean.
+	 *
+	 * 	@example
+	 * ```ts
+	 * canCreateInvitation: async (user) => {
+	 * 		const canInvite: boolean = await hasPermission(user, 'send-invitation');
+	 *      return canInvite;
+	 * }
+	 * ```
+	 * @default true
+	 */
+	canCreateInvitation?: ((ctx: GenericEndpointContext) => Promise<boolean> | boolean) | boolean;
+	/**
+	 * Define whether a user is allowed to cancel invitations.
+	 *
+	 * By default users can only cancel invitations issued by themself.
+	 */
+	canCancelInvitation?:
+		| ((
+				ctx: GenericEndpointContext,
+				invite: AppInvitation & Record<string, any>,
+		  ) => Promise<boolean> | boolean)
+		| boolean;
+	/**
+	 * Send an email with the invitation link to the user.
+	 */
+	sendInvitationEmail?: (
+		invitation: AppInvitation & {
+			type: AppInvitationType;
+			inviter: User & Record<string, any>;
+		},
+		request: Request | undefined,
+	) => Promise<void>;
+	/**
+	 * The expiration time for the invitation link.
+	 *
+	 * @default 48 hours
+	 */
+	invitationExpiresIn?: number | null;
+	/**
+	 * Automatically sign in the user after sign up.
+	 */
+	autoSignIn?: boolean;
+	/**
+	 * Clean up expires invitations when a value is fetched.
+	 *
+	 * @default true
+	 */
+	cleanupExpiredInvitations?: boolean;
+	/**
+	 * Delete personal invitations when a decision is made
+	 * (accept/reject) on one of them.
+	 *
+	 * @default false
+	 */
+	cleanupPersonalInvitesOnDecision?: boolean;
+	/**
+	 * If true, mark the user's email as verified upon accepting an invitation
+	 *
+	 * @default true
+	 */
+	verifyEmailOnAccept?: boolean;
+	/**
+	 * Rate limit configuration.
+	 *
+	 * @default {
+	 *  window: 60,
+	 *  max: 5,
+	 * }
+	 */
+	rateLimit?: {
+		window: number;
+		max: number;
+	};
+	/**
+	 * Invitation lifecycle hooks
+	 */
+	hooks?: {
+		create?: {
+			before?: (ctx: GenericEndpointContext) => Promise<void> | void;
+			after?: (
+				ctx: GenericEndpointContext,
+				invitation: AppInvitation & Record<string, any>,
+			) => Promise<void> | void;
+		};
+		accept?: {
+			before?: (
+				ctx: GenericEndpointContext,
+				userToCreate: Partial<User> & { email: string } & Record<string, any>,
+			) =>
+				| Promise<{
+						user?: User & Record<string, any>;
+				  } | void>
+				| {
+						user?: User & Record<string, any>;
+				  }
+				| void;
+			after?: (
+				ctx: GenericEndpointContext,
+				data: {
+					invitation: AppInvitation & Record<string, any>;
+					user: User & Record<string, any>;
+				},
+			) => Promise<void> | void;
+		};
+		reject?: {
+			before?: (
+				ctx: GenericEndpointContext,
+				invitation: AppInvitation & Record<string, any>,
+			) => Promise<void> | void;
+			after?: (
+				ctx: GenericEndpointContext,
+				invitation: AppInvitation & Record<string, any>,
+			) => Promise<void> | void;
+		};
+		cancel?: {
+			before?: (
+				ctx: GenericEndpointContext,
+				invitation: AppInvitation & Record<string, any>,
+			) => Promise<void> | void;
+			after?: (
+				ctx: GenericEndpointContext,
+				invitation: AppInvitation & Record<string, any>,
+			) => Promise<void> | void;
+		};
+	};
+	/**
+	 * The schema for the app-invite plugin.
+	 */
+	schema?: {
+		appInvitation?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<AppInvitation, "id">]?: string;
+			};
+			/**
+			 * Add extra invitation colums
+			 */
+			additionalFields?: {
+				[key in string]: FieldAttribute;
+			};
+		};
+		user?: {
+			/**
+			 * Add extra user columns used by this plugin.
+			 *
+			 * (Note: These fields won't be included in the database schema,
+			 * assuming they're already defined in `BetterAuthOptions`)
+			 */
+			additionalFields?: {
+				[key in string]: FieldAttribute;
+			};
+		};
+	};
+};
+
+export type * from "better-call";

--- a/packages/plugins/app-invite/src/types.ts
+++ b/packages/plugins/app-invite/src/types.ts
@@ -28,7 +28,7 @@ export type AppInviteOptions = {
 	/**
 	 * Define whether a user is allowed to cancel invitations.
 	 *
-	 * By default users can only cancel invitations issued by themself.
+	 * By default users can only cancel invitations issued by themselves.
 	 *
 	 * @deprecated use `canCancelInvitation` instead.
 	 */
@@ -85,7 +85,7 @@ export type AppInviteOptions = {
 	 */
 	autoSignIn?: boolean;
 	/**
-	 * Clean up expires invitations when a value is fetched.
+	 * Clean up expired invitations when a value is fetched.
 	 *
 	 * @default true
 	 */
@@ -185,7 +185,7 @@ export type AppInviteOptions = {
 				[key in keyof Omit<AppInvitation, "id">]?: string;
 			};
 			/**
-			 * Add extra invitation colums
+			 * Add extra invitation columns.
 			 */
 			additionalFields?: {
 				[key in string]: FieldAttribute;

--- a/packages/plugins/app-invite/src/types.ts
+++ b/packages/plugins/app-invite/src/types.ts
@@ -104,6 +104,14 @@ export type AppInviteOptions = {
 	 */
 	verifyEmailOnAccept?: boolean;
 	/**
+	 * If true, resends an existing invitation.
+	 * 
+	 * By default a new invitation is created.
+	 * 
+	 * @default false
+	 */
+	resendExistingInvite?: boolean;
+	/**
 	 * Rate limit configuration.
 	 *
 	 * @default {

--- a/packages/plugins/app-invite/src/types.ts
+++ b/packages/plugins/app-invite/src/types.ts
@@ -105,9 +105,9 @@ export type AppInviteOptions = {
 	verifyEmailOnAccept?: boolean;
 	/**
 	 * If true, resends an existing invitation.
-	 * 
+	 *
 	 * By default a new invitation is created.
-	 * 
+	 *
 	 * @default false
 	 */
 	resendExistingInvite?: boolean;

--- a/packages/plugins/app-invite/src/utils.ts
+++ b/packages/plugins/app-invite/src/utils.ts
@@ -1,4 +1,7 @@
-import { type InferAdditionalFieldsFromPluginOptions, toZodSchema } from "better-auth/db";
+import {
+	type InferAdditionalFieldsFromPluginOptions,
+	toZodSchema,
+} from "better-auth/db";
 import type { AppInviteOptions } from "./types";
 import type { AuthContext, BetterAuthPlugin } from "better-auth";
 
@@ -9,11 +12,15 @@ export const getPlugin = <P extends BetterAuthPlugin = BetterAuthPlugin>(
 	return context.options.plugins?.find((p) => p.id === id) as P | undefined;
 };
 
-export const getAdditionalFields = <O extends AppInviteOptions, AllPartial extends boolean = false>(
+export const getAdditionalFields = <
+	O extends AppInviteOptions,
+	AllPartial extends boolean = false,
+>(
 	options: O,
 	shouldBePartial: AllPartial = false as AllPartial,
 ) => {
-	const additionalFields = options.schema?.appInvitation?.additionalFields || {};
+	const additionalFields =
+		options.schema?.appInvitation?.additionalFields || {};
 	if (shouldBePartial) {
 		for (const key in additionalFields) {
 			additionalFields[key]!.required = false;
@@ -26,7 +33,11 @@ export const getAdditionalFields = <O extends AppInviteOptions, AllPartial exten
 	type AdditionalFields = AllPartial extends true
 		? Partial<InferAdditionalFieldsFromPluginOptions<"appInvitation", O>>
 		: InferAdditionalFieldsFromPluginOptions<"appInvitation", O>;
-	type ReturnAdditionalFields = InferAdditionalFieldsFromPluginOptions<"appInvitation", O, false>;
+	type ReturnAdditionalFields = InferAdditionalFieldsFromPluginOptions<
+		"appInvitation",
+		O,
+		false
+	>;
 
 	return {
 		additionalFieldsSchema,

--- a/packages/plugins/app-invite/src/utils.ts
+++ b/packages/plugins/app-invite/src/utils.ts
@@ -1,0 +1,38 @@
+import { type InferAdditionalFieldsFromPluginOptions, toZodSchema } from "better-auth/db";
+import type { AppInviteOptions } from "./types";
+import type { AuthContext, BetterAuthPlugin } from "better-auth";
+
+export const getPlugin = <P extends BetterAuthPlugin = BetterAuthPlugin>(
+	id: string,
+	context: AuthContext,
+) => {
+	return context.options.plugins?.find((p) => p.id === id) as P | undefined;
+};
+
+export const getAdditionalFields = <O extends AppInviteOptions, AllPartial extends boolean = false>(
+	options: O,
+	shouldBePartial: AllPartial = false as AllPartial,
+) => {
+	const additionalFields = options.schema?.appInvitation?.additionalFields || {};
+	if (shouldBePartial) {
+		for (const key in additionalFields) {
+			additionalFields[key]!.required = false;
+		}
+	}
+	const additionalFieldsSchema = toZodSchema({
+		fields: additionalFields,
+		isClientSide: true,
+	});
+	type AdditionalFields = AllPartial extends true
+		? Partial<InferAdditionalFieldsFromPluginOptions<"appInvitation", O>>
+		: InferAdditionalFieldsFromPluginOptions<"appInvitation", O>;
+	type ReturnAdditionalFields = InferAdditionalFieldsFromPluginOptions<"appInvitation", O, false>;
+
+	return {
+		additionalFieldsSchema,
+		$AdditionalFields: {} as AllPartial extends true
+			? Partial<AdditionalFields>
+			: AdditionalFields,
+		$ReturnAdditionalFields: {} as ReturnAdditionalFields,
+	};
+};

--- a/packages/plugins/app-invite/tsconfig.json
+++ b/packages/plugins/app-invite/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "es2022",
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"module": "ESNext",
+		"noEmit": true,
+		"moduleResolution": "Bundler",
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["src"]
+}

--- a/packages/plugins/app-invite/tsconfig.json
+++ b/packages/plugins/app-invite/tsconfig.json
@@ -1,20 +1,20 @@
 {
-	"compilerOptions": {
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"target": "es2022",
-		"allowJs": true,
-		"resolveJsonModule": true,
-		"module": "ESNext",
-		"noEmit": true,
-		"moduleResolution": "Bundler",
-		"moduleDetection": "force",
-		"isolatedModules": true,
-		"verbatimModuleSyntax": true,
-		"strict": true,
-		"noImplicitOverride": true,
-		"noFallthroughCasesInSwitch": true
-	},
-	"exclude": ["node_modules", "dist"],
-	"include": ["src"]
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "module": "ESNext",
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ catalogs:
       specifier: ^1.3.8-beta.10
       version: 1.3.8-beta.10
   default:
+    better-call:
+      specifier: ^1.0.15
+      version: 1.0.15
     typescript:
       specifier: ^5.9.2
       version: 5.9.2
@@ -22,6 +25,9 @@ catalogs:
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
+    zod:
+      specifier: ^4.1.5
+      version: 4.1.5
 
 importers:
 
@@ -96,6 +102,37 @@ importers:
       better-auth:
         specifier: catalog:better-auth
         version: 1.3.8-beta.10
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(typescript@5.9.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@22.15.18)(jiti@2.5.1)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/plugins/app-invite:
+    dependencies:
+      '@better-auth-extended/internal-env':
+        specifier: workspace:*
+        version: link:../../internal/env
+      '@better-auth-extended/internal-utils':
+        specifier: workspace:*
+        version: link:../../internal/utils
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.5
+    devDependencies:
+      '@better-auth-extended/test-utils':
+        specifier: workspace:*
+        version: link:../../libraries/test-utils
+      better-auth:
+        specifier: catalog:better-auth
+        version: 1.3.8-beta.10
+      better-call:
+        specifier: 'catalog:'
+        version: 1.0.15
       typescript:
         specifier: 'catalog:'
         version: 5.9.2


### PR DESCRIPTION
 ## Todo
 
 - [X] Additional Fields (User & Invitation)
 - [X] Cleanup expired invitations
 - [X] Cleanup invitations on decision
 - [X] Lifecycle hooks
 - [ ] (Admin plugin support)
 - [X] Wildcard domains
 - [x] Optionally resend with same invitation
 - [x] Tests
 - [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - App Invite plugin: create/get/list/accept/reject/cancel invitations (personal & public), domain whitelists, expirations, resend, hooks, rate limiting, optional email verification and auto sign-in, client actions, standardized error codes, strong typings and schemas.
- Documentation
  - Added comprehensive README with installation, configuration, schema, usage flows, options, and migration notes.
- Tests
  - End-to-end integration tests covering invitation lifecycle, domain rules, hooks, resend/cleanup, and auth flows.
- Chores
  - Package manifest, build and TS configs, and MIT license added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->