### PR TITLE
chore: upgrade better-auth to 1.5.x

### DIFF
--- a/.changeset/puny-paths-write.md
+++ b/.changeset/puny-paths-write.md
@@ -1,0 +1,8 @@
+---
+"@better-auth-extended/test-utils": major
+"@better-auth-extended/preferences": major
+"@better-auth-extended/app-invite": major
+"@better-auth-extended/onboarding": major
+---
+
+Upgrade better-auth to 1.5.x — migrate to defineErrorCodes, APIError.from(), and updated import paths

--- a/packages/libraries/test-utils/src/test-instance.ts
+++ b/packages/libraries/test-utils/src/test-instance.ts
@@ -172,7 +172,8 @@ export const getTestInstance = async <
 			...((config?.clientOptions?.plugins as C["plugins"]) || []),
 		],
 		baseURL: getBaseURL(
-			(config?.options?.baseURL as string) || "http://localhost:" + (config?.port || 3000),
+			(config?.options?.baseURL as string) ||
+				"http://localhost:" + (config?.port || 3000),
 			config?.options?.basePath || "/api/auth",
 		),
 		fetchOptions: {

--- a/packages/libraries/test-utils/src/test-instance.ts
+++ b/packages/libraries/test-utils/src/test-instance.ts
@@ -13,7 +13,8 @@ import {
 	type SuccessContext,
 } from "better-auth/client";
 import { bearer } from "better-auth/plugins/bearer";
-import { getMigrations, getAuthTables } from "better-auth/db";
+import { getAuthTables } from "better-auth/db";
+import { getMigrations } from "better-auth/db/migration";
 import { parseSetCookieHeader, setCookieToHeader } from "better-auth/cookies";
 import { getBaseURL } from "@better-auth-extended/internal-utils";
 import type { DBAdapter } from "better-auth/adapters";
@@ -171,7 +172,7 @@ export const getTestInstance = async <
 			...((config?.clientOptions?.plugins as C["plugins"]) || []),
 		],
 		baseURL: getBaseURL(
-			config?.options?.baseURL || "http://localhost:" + (config?.port || 3000),
+			(config?.options?.baseURL as string) || "http://localhost:" + (config?.port || 3000),
 			config?.options?.basePath || "/api/auth",
 		),
 		fetchOptions: {

--- a/packages/plugins/app-invite/src/app-invite.test.ts
+++ b/packages/plugins/app-invite/src/app-invite.test.ts
@@ -348,11 +348,11 @@ describe("App Invite", async () => {
 					if (action === "accept-invitation") {
 						expect(res.data?.user.email).toBe(invitee.email);
 					}
-					if (action === "accept-invitation-expect-error") {
-						expect(res.error?.message).toBe(
-							APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST,
-						);
-					}
+				if (action === "accept-invitation-expect-error") {
+					expect(res.error?.code).toBe(
+						APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST.code,
+					);
+				}
 					break;
 				}
 				case "reject-invitation": {

--- a/packages/plugins/app-invite/src/app-invite.test.ts
+++ b/packages/plugins/app-invite/src/app-invite.test.ts
@@ -348,11 +348,11 @@ describe("App Invite", async () => {
 					if (action === "accept-invitation") {
 						expect(res.data?.user.email).toBe(invitee.email);
 					}
-				if (action === "accept-invitation-expect-error") {
-					expect(res.error?.code).toBe(
-						APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST.code,
-					);
-				}
+					if (action === "accept-invitation-expect-error") {
+						expect(res.error?.code).toBe(
+							APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST.code,
+						);
+					}
 					break;
 				}
 				case "reject-invitation": {

--- a/packages/plugins/app-invite/src/error-codes.ts
+++ b/packages/plugins/app-invite/src/error-codes.ts
@@ -1,44 +1,46 @@
-export const APP_INVITE_ERROR_CODES = {
-	USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION:
-		"User is already a member of this application",
-	USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION:
-		"User was already invited to this application",
-	INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
-		"Inviter is no longer a member of this application",
-	APP_INVITATION_NOT_FOUND: "App invitation not found",
-	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION:
-		"You are not allowed to cancel this app invitation",
-	YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION:
-		"You are not allowed to invite users to this application",
-	THIS_APP_INVITATION_CANT_BE_REJECTED: "This app invitation can't be rejected",
-	EMAIL_DOMAIN_IS_NOT_IN_WHITELIST: "Email domain is not in whitelist",
-	ADMIN_PLUGIN_IS_NOT_SET_UP: "Admin plugin is not set-up.",
-} as const;
+import { defineErrorCodes } from "better-auth";
 
-export const BASE_ERROR_CODES = {
-	USER_NOT_FOUND: "User not found",
-	FAILED_TO_CREATE_USER: "Failed to create user",
-	FAILED_TO_CREATE_SESSION: "Failed to create session",
-	FAILED_TO_UPDATE_USER: "Failed to update user",
-	FAILED_TO_GET_SESSION: "Failed to get session",
-	INVALID_PASSWORD: "Invalid password",
-	INVALID_EMAIL: "Invalid email",
-	INVALID_EMAIL_OR_PASSWORD: "Invalid email or password",
-	SOCIAL_ACCOUNT_ALREADY_LINKED: "Social account already linked",
-	PROVIDER_NOT_FOUND: "Provider not found",
-	INVALID_TOKEN: "invalid token",
-	ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
-	FAILED_TO_GET_USER_INFO: "Failed to get user info",
-	USER_EMAIL_NOT_FOUND: "User email not found",
-	EMAIL_NOT_VERIFIED: "Email not verified",
-	PASSWORD_TOO_SHORT: "Password too short",
-	PASSWORD_TOO_LONG: "Password too long",
-	USER_ALREADY_EXISTS: "User already exists",
-	EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
-	CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
-	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
-	FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
-	ACCOUNT_NOT_FOUND: "Account not found",
-	USER_ALREADY_HAS_PASSWORD:
-		"User already has a password. Provide that to delete the account.",
-};
+export const APP_INVITE_ERROR_CODES = defineErrorCodes({
+  USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION:
+    "User is already a member of this application",
+  USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION:
+    "User was already invited to this application",
+  INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
+    "Inviter is no longer a member of this application",
+  APP_INVITATION_NOT_FOUND: "App invitation not found",
+  YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION:
+    "You are not allowed to cancel this app invitation",
+  YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION:
+    "You are not allowed to invite users to this application",
+  THIS_APP_INVITATION_CANT_BE_REJECTED: "This app invitation can't be rejected",
+  EMAIL_DOMAIN_IS_NOT_IN_WHITELIST: "Email domain is not in whitelist",
+  ADMIN_PLUGIN_IS_NOT_SET_UP: "Admin plugin is not set-up.",
+});
+
+export const BASE_ERROR_CODES = defineErrorCodes({
+  USER_NOT_FOUND: "User not found",
+  FAILED_TO_CREATE_USER: "Failed to create user",
+  FAILED_TO_CREATE_SESSION: "Failed to create session",
+  FAILED_TO_UPDATE_USER: "Failed to update user",
+  FAILED_TO_GET_SESSION: "Failed to get session",
+  INVALID_PASSWORD: "Invalid password",
+  INVALID_EMAIL: "Invalid email",
+  INVALID_EMAIL_OR_PASSWORD: "Invalid email or password",
+  SOCIAL_ACCOUNT_ALREADY_LINKED: "Social account already linked",
+  PROVIDER_NOT_FOUND: "Provider not found",
+  INVALID_TOKEN: "invalid token",
+  ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
+  FAILED_TO_GET_USER_INFO: "Failed to get user info",
+  USER_EMAIL_NOT_FOUND: "User email not found",
+  EMAIL_NOT_VERIFIED: "Email not verified",
+  PASSWORD_TOO_SHORT: "Password too short",
+  PASSWORD_TOO_LONG: "Password too long",
+  USER_ALREADY_EXISTS: "User already exists",
+  EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
+  CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
+  SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
+  FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
+  ACCOUNT_NOT_FOUND: "Account not found",
+  USER_ALREADY_HAS_PASSWORD:
+    "User already has a password. Provide that to delete the account.",
+});

--- a/packages/plugins/app-invite/src/error-codes.ts
+++ b/packages/plugins/app-invite/src/error-codes.ts
@@ -1,46 +1,46 @@
 import { defineErrorCodes } from "better-auth";
 
 export const APP_INVITE_ERROR_CODES = defineErrorCodes({
-  USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION:
-    "User is already a member of this application",
-  USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION:
-    "User was already invited to this application",
-  INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
-    "Inviter is no longer a member of this application",
-  APP_INVITATION_NOT_FOUND: "App invitation not found",
-  YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION:
-    "You are not allowed to cancel this app invitation",
-  YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION:
-    "You are not allowed to invite users to this application",
-  THIS_APP_INVITATION_CANT_BE_REJECTED: "This app invitation can't be rejected",
-  EMAIL_DOMAIN_IS_NOT_IN_WHITELIST: "Email domain is not in whitelist",
-  ADMIN_PLUGIN_IS_NOT_SET_UP: "Admin plugin is not set-up.",
+	USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION:
+		"User is already a member of this application",
+	USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION:
+		"User was already invited to this application",
+	INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION:
+		"Inviter is no longer a member of this application",
+	APP_INVITATION_NOT_FOUND: "App invitation not found",
+	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION:
+		"You are not allowed to cancel this app invitation",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION:
+		"You are not allowed to invite users to this application",
+	THIS_APP_INVITATION_CANT_BE_REJECTED: "This app invitation can't be rejected",
+	EMAIL_DOMAIN_IS_NOT_IN_WHITELIST: "Email domain is not in whitelist",
+	ADMIN_PLUGIN_IS_NOT_SET_UP: "Admin plugin is not set-up.",
 });
 
 export const BASE_ERROR_CODES = defineErrorCodes({
-  USER_NOT_FOUND: "User not found",
-  FAILED_TO_CREATE_USER: "Failed to create user",
-  FAILED_TO_CREATE_SESSION: "Failed to create session",
-  FAILED_TO_UPDATE_USER: "Failed to update user",
-  FAILED_TO_GET_SESSION: "Failed to get session",
-  INVALID_PASSWORD: "Invalid password",
-  INVALID_EMAIL: "Invalid email",
-  INVALID_EMAIL_OR_PASSWORD: "Invalid email or password",
-  SOCIAL_ACCOUNT_ALREADY_LINKED: "Social account already linked",
-  PROVIDER_NOT_FOUND: "Provider not found",
-  INVALID_TOKEN: "invalid token",
-  ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
-  FAILED_TO_GET_USER_INFO: "Failed to get user info",
-  USER_EMAIL_NOT_FOUND: "User email not found",
-  EMAIL_NOT_VERIFIED: "Email not verified",
-  PASSWORD_TOO_SHORT: "Password too short",
-  PASSWORD_TOO_LONG: "Password too long",
-  USER_ALREADY_EXISTS: "User already exists",
-  EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
-  CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
-  SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
-  FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
-  ACCOUNT_NOT_FOUND: "Account not found",
-  USER_ALREADY_HAS_PASSWORD:
-    "User already has a password. Provide that to delete the account.",
+	USER_NOT_FOUND: "User not found",
+	FAILED_TO_CREATE_USER: "Failed to create user",
+	FAILED_TO_CREATE_SESSION: "Failed to create session",
+	FAILED_TO_UPDATE_USER: "Failed to update user",
+	FAILED_TO_GET_SESSION: "Failed to get session",
+	INVALID_PASSWORD: "Invalid password",
+	INVALID_EMAIL: "Invalid email",
+	INVALID_EMAIL_OR_PASSWORD: "Invalid email or password",
+	SOCIAL_ACCOUNT_ALREADY_LINKED: "Social account already linked",
+	PROVIDER_NOT_FOUND: "Provider not found",
+	INVALID_TOKEN: "invalid token",
+	ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
+	FAILED_TO_GET_USER_INFO: "Failed to get user info",
+	USER_EMAIL_NOT_FOUND: "User email not found",
+	EMAIL_NOT_VERIFIED: "Email not verified",
+	PASSWORD_TOO_SHORT: "Password too short",
+	PASSWORD_TOO_LONG: "Password too long",
+	USER_ALREADY_EXISTS: "User already exists",
+	EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
+	CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
+	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
+	FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",
+	ACCOUNT_NOT_FOUND: "Account not found",
+	USER_ALREADY_HAS_PASSWORD:
+		"User already has a password. Provide that to delete the account.",
 });

--- a/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
@@ -1,8 +1,8 @@
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 import type { AppInviteOptions } from "../types";
 import { z } from "zod";
 import {
-	type InferFieldsInput,
+	type InferDBFieldsInput,
 	parseUserInput,
 	toZodSchema,
 } from "better-auth/db";
@@ -32,7 +32,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 			additionalFields: infer Field;
 		};
 	}
-		? InferFieldsInput<Field>
+		? InferDBFieldsInput<Field>
 		: {};
 
 	type ReturnAdditionalFields =
@@ -176,9 +176,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-				throw new APIError("BAD_REQUEST", {
-					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
 			}
 
 			const invitationType = invitation.email ? "personal" : "public";
@@ -187,10 +185,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				invitation.inviterId,
 			);
 			if (!inviter) {
-				throw new APIError("BAD_REQUEST", {
-					message:
-						APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION);
 			}
 
 			let userData = {
@@ -206,9 +201,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				ctx.context.logger.info(
 					`Sign-up attempt for existing email: ${userData.email}`,
 				);
-				throw new APIError("UNPROCESSABLE_ENTITY", {
-					message: BASE_ERROR_CODES.USER_ALREADY_EXISTS,
-				});
+			throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.USER_ALREADY_EXISTS);
 			}
 
 			const before = await options.hooks?.accept?.before?.(ctx, userData);
@@ -218,9 +211,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 			const isValidEmail = z.email().safeParse(userData.email);
 
 			if (!isValidEmail.success) {
-				throw new APIError("BAD_REQUEST", {
-					message: BASE_ERROR_CODES.INVALID_EMAIL,
-				});
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_EMAIL);
 			}
 
 			if (invitationType === "public") {
@@ -236,25 +227,19 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 						isMatch(wDomain.trim().toLowerCase()),
 					)
 				) {
-					throw new APIError("FORBIDDEN", {
-						message: APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST,
-					});
+				throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST);
 				}
 			}
 
 			const minPasswordLength = ctx.context.password.config.minPasswordLength;
 			if (ctx.body.password.length < minPasswordLength) {
 				ctx.context.logger.error("Password is too short");
-				throw new APIError("BAD_REQUEST", {
-					message: BASE_ERROR_CODES.PASSWORD_TOO_SHORT,
-				});
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
 			}
 			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 			if (ctx.body.password.length > maxPasswordLength) {
 				ctx.context.logger.error("Password is too long");
-				throw new APIError("BAD_REQUEST", {
-					message: BASE_ERROR_CODES.PASSWORD_TOO_LONG,
-				});
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
 
 			const additionalData = parseUserInput(
@@ -272,9 +257,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 					emailVerified: options.verifyEmailOnAccept,
 				});
 				if (!createdUser) {
-					throw new APIError("UNPROCESSABLE_ENTITY", {
-						message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
-					});
+					throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.FAILED_TO_CREATE_USER);
 				}
 			} catch (e) {
 				if (isDevelopment) {
@@ -284,25 +267,20 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 					throw e;
 				}
 				throw new APIError("UNPROCESSABLE_ENTITY", {
-					message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+					...BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
 					details: e,
 				});
 			}
 			if (!createdUser) {
-				throw new APIError("UNPROCESSABLE_ENTITY", {
-					message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
-				});
+				throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.FAILED_TO_CREATE_USER);
 			}
 
-			await ctx.context.internalAdapter.linkAccount(
-				{
-					userId: createdUser.id,
-					providerId: "credential",
-					accountId: createdUser.id,
-					password: hash,
-				},
-				ctx,
-			);
+			await ctx.context.internalAdapter.linkAccount({
+				userId: createdUser.id,
+				providerId: "credential",
+				accountId: createdUser.id,
+				password: hash,
+			});
 
 			let acceptedI: AppInvitation | null = invitation;
 			if (invitationType === "personal" && invitation.email) {
@@ -416,12 +394,9 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 
 			const session = await ctx.context.internalAdapter.createSession(
 				createdUser.id,
-				ctx,
 			);
 			if (!session) {
-				throw new APIError("BAD_REQUEST", {
-					message: BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
-				});
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION);
 			}
 			await setSessionCookie(ctx, {
 				session,

--- a/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/accept-app-invitation.ts
@@ -176,7 +176,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				);
 			}
 
 			const invitationType = invitation.email ? "personal" : "public";
@@ -185,7 +188,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				invitation.inviterId,
 			);
 			if (!inviter) {
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
+				);
 			}
 
 			let userData = {
@@ -201,7 +207,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				ctx.context.logger.info(
 					`Sign-up attempt for existing email: ${userData.email}`,
 				);
-			throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.USER_ALREADY_EXISTS);
+				throw APIError.from(
+					"UNPROCESSABLE_ENTITY",
+					BASE_ERROR_CODES.USER_ALREADY_EXISTS,
+				);
 			}
 
 			const before = await options.hooks?.accept?.before?.(ctx, userData);
@@ -211,7 +220,7 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 			const isValidEmail = z.email().safeParse(userData.email);
 
 			if (!isValidEmail.success) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_EMAIL);
+				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_EMAIL);
 			}
 
 			if (invitationType === "public") {
@@ -227,19 +236,22 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 						isMatch(wDomain.trim().toLowerCase()),
 					)
 				) {
-				throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST);
+					throw APIError.from(
+						"FORBIDDEN",
+						APP_INVITE_ERROR_CODES.EMAIL_DOMAIN_IS_NOT_IN_WHITELIST,
+					);
 				}
 			}
 
 			const minPasswordLength = ctx.context.password.config.minPasswordLength;
 			if (ctx.body.password.length < minPasswordLength) {
 				ctx.context.logger.error("Password is too short");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
+				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
 			}
 			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 			if (ctx.body.password.length > maxPasswordLength) {
 				ctx.context.logger.error("Password is too long");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
+				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
 
 			const additionalData = parseUserInput(
@@ -257,7 +269,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 					emailVerified: options.verifyEmailOnAccept,
 				});
 				if (!createdUser) {
-					throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.FAILED_TO_CREATE_USER);
+					throw APIError.from(
+						"UNPROCESSABLE_ENTITY",
+						BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+					);
 				}
 			} catch (e) {
 				if (isDevelopment) {
@@ -272,7 +287,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				});
 			}
 			if (!createdUser) {
-				throw APIError.from("UNPROCESSABLE_ENTITY", BASE_ERROR_CODES.FAILED_TO_CREATE_USER);
+				throw APIError.from(
+					"UNPROCESSABLE_ENTITY",
+					BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
+				);
 			}
 
 			await ctx.context.internalAdapter.linkAccount({
@@ -396,7 +414,10 @@ export const acceptAppInvitation = <O extends AppInviteOptions>(
 				createdUser.id,
 			);
 			if (!session) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION);
+				throw APIError.from(
+					"BAD_REQUEST",
+					BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
+				);
 			}
 			await setSessionCookie(ctx, {
 				session,

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -1,5 +1,5 @@
 import { APIError, sessionMiddleware } from "better-auth/api";
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 import { z } from "zod";
 import type { AppInviteOptions } from "../types";
 import { getAppInviteAdapter } from "../adapter";
@@ -71,9 +71,7 @@ export const cancelAppInvitation = <O extends AppInviteOptions>(
 				},
 			);
 			if (!invitation) {
-				throw new APIError("BAD_REQUEST", {
-					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
 			}
 			let hasAccess: boolean = false;
 			if (options.allowUserToCancelInvitation) {
@@ -97,10 +95,7 @@ export const cancelAppInvitation = <O extends AppInviteOptions>(
 						: canCancel;
 			}
 			if (!hasAccess) {
-				throw new APIError("FORBIDDEN", {
-					message:
-						APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION,
-				});
+			throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION);
 			}
 
 			await options.hooks?.cancel?.before?.(ctx, invitation);

--- a/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/cancel-app-invitation.ts
@@ -71,7 +71,10 @@ export const cancelAppInvitation = <O extends AppInviteOptions>(
 				},
 			);
 			if (!invitation) {
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				);
 			}
 			let hasAccess: boolean = false;
 			if (options.allowUserToCancelInvitation) {
@@ -95,7 +98,10 @@ export const cancelAppInvitation = <O extends AppInviteOptions>(
 						: canCancel;
 			}
 			if (!hasAccess) {
-			throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION);
+				throw APIError.from(
+					"FORBIDDEN",
+					APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_APP_INVITATION,
+				);
 			}
 
 			await options.hooks?.cancel?.before?.(ctx, invitation);

--- a/packages/plugins/app-invite/src/routes/create-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/create-app-invitation.ts
@@ -101,7 +101,10 @@ export const createAppInvitation = <
 						: canCreate;
 			}
 			if (!hasAccess) {
-			throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION);
+				throw APIError.from(
+					"FORBIDDEN",
+					APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION,
+				);
 			}
 
 			const adapter = getAppInviteAdapter(ctx.context, options);
@@ -115,7 +118,10 @@ export const createAppInvitation = <
 					ctx.body.email,
 				);
 				if (alreadyMember) {
-				throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION);
+					throw APIError.from(
+						"BAD_REQUEST",
+						APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION,
+					);
 				}
 				const alreadyInvited = await adapter.findInvitationByEmail(
 					ctx.body.email,
@@ -129,7 +135,10 @@ export const createAppInvitation = <
 					},
 				);
 				if (alreadyInvited && !ctx.body.resend) {
-				throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION);
+					throw APIError.from(
+						"BAD_REQUEST",
+						APP_INVITE_ERROR_CODES.USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION,
+					);
 				}
 			}
 

--- a/packages/plugins/app-invite/src/routes/create-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/create-app-invitation.ts
@@ -1,5 +1,5 @@
 import { APIError, sessionMiddleware } from "better-auth/api";
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 import type { AppInviteOptions } from "../types";
 import { APP_INVITE_ERROR_CODES } from "../error-codes";
 import { getAppInviteAdapter } from "../adapter";
@@ -101,10 +101,7 @@ export const createAppInvitation = <
 						: canCreate;
 			}
 			if (!hasAccess) {
-				throw new APIError("FORBIDDEN", {
-					message:
-						APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION,
-				});
+			throw APIError.from("FORBIDDEN", APP_INVITE_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_APPLICATION);
 			}
 
 			const adapter = getAppInviteAdapter(ctx.context, options);
@@ -118,10 +115,7 @@ export const createAppInvitation = <
 					ctx.body.email,
 				);
 				if (alreadyMember) {
-					throw new APIError("BAD_REQUEST", {
-						message:
-							APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION,
-					});
+				throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_APPLICATION);
 				}
 				const alreadyInvited = await adapter.findInvitationByEmail(
 					ctx.body.email,
@@ -135,10 +129,7 @@ export const createAppInvitation = <
 					},
 				);
 				if (alreadyInvited && !ctx.body.resend) {
-					throw new APIError("BAD_REQUEST", {
-						message:
-							APP_INVITE_ERROR_CODES.USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION,
-					});
+				throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.USER_WAS_ALREADY_INVITED_TO_THIS_APPLICATION);
 				}
 			}
 

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 import type { AppInviteOptions } from "../types";
 import { z } from "zod";
 import { getAppInviteAdapter } from "../adapter";
@@ -94,19 +94,14 @@ export const getAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-				throw new APIError("BAD_REQUEST", {
-					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
 			}
 
 			const inviter = await ctx.context.internalAdapter.findUserById(
 				invitation.inviterId,
 			);
 			if (!inviter) {
-				throw new APIError("BAD_REQUEST", {
-					message:
-						APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION);
 			}
 
 			const data = {

--- a/packages/plugins/app-invite/src/routes/get-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/get-app-invitation.ts
@@ -94,14 +94,20 @@ export const getAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				);
 			}
 
 			const inviter = await ctx.context.internalAdapter.findUserById(
 				invitation.inviterId,
 			);
 			if (!inviter) {
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THIS_APPLICATION,
+				);
 			}
 
 			const data = {

--- a/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
@@ -105,10 +105,16 @@ export const rejectAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
+				);
 			}
 			if (type === "public") {
-			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.THIS_APP_INVITATION_CANT_BE_REJECTED);
+				throw APIError.from(
+					"BAD_REQUEST",
+					APP_INVITE_ERROR_CODES.THIS_APP_INVITATION_CANT_BE_REJECTED,
+				);
 			}
 
 			await options.hooks?.reject?.before?.(ctx, invitation);

--- a/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
+++ b/packages/plugins/app-invite/src/routes/reject-app-invitation.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 import type { AppInviteOptions } from "../types";
 import { z } from "zod";
 import { APIError, originCheck } from "better-auth/api";
@@ -105,14 +105,10 @@ export const rejectAppInvitation = <O extends AppInviteOptions>(
 						await adapter.updateInvitation(invitation.id, "expired");
 					}
 				}
-				throw new APIError("BAD_REQUEST", {
-					message: APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.APP_INVITATION_NOT_FOUND);
 			}
 			if (type === "public") {
-				throw new APIError("BAD_REQUEST", {
-					message: APP_INVITE_ERROR_CODES.THIS_APP_INVITATION_CANT_BE_REJECTED,
-				});
+			throw APIError.from("BAD_REQUEST", APP_INVITE_ERROR_CODES.THIS_APP_INVITATION_CANT_BE_REJECTED);
 			}
 
 			await options.hooks?.reject?.before?.(ctx, invitation);

--- a/packages/plugins/app-invite/src/utils.ts
+++ b/packages/plugins/app-invite/src/utils.ts
@@ -39,7 +39,7 @@ export const checkPermission = async (
 	if (!adminPlugin) {
 		ctx.context.logger.error("Admin plugin is not set-up.");
 		throw ctx.error("FAILED_DEPENDENCY", {
-			message: APP_INVITE_ERROR_CODES.ADMIN_PLUGIN_IS_NOT_SET_UP,
+			...APP_INVITE_ERROR_CODES.ADMIN_PLUGIN_IS_NOT_SET_UP,
 		});
 	}
 

--- a/packages/plugins/onboarding/src/error-codes.ts
+++ b/packages/plugins/onboarding/src/error-codes.ts
@@ -1,6 +1,8 @@
-export const ONBOARDING_ERROR_CODES = {
+import { defineErrorCodes } from "better-auth";
+
+export const ONBOARDING_ERROR_CODES = defineErrorCodes({
 	ALREADY_ONBOARDED: "Already onboarded.",
 	STEP_ALREADY_COMPLETED: "Step already completed.",
 	COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING:
 		"Complete required steps before completing onboarding.",
-} as const;
+});

--- a/packages/plugins/onboarding/src/index.ts
+++ b/packages/plugins/onboarding/src/index.ts
@@ -7,7 +7,6 @@ import {
 	createAuthMiddleware,
 	APIError,
 	sessionMiddleware,
-	type AuthEndpoint,
 } from "better-auth/api";
 import type { OnboardingOptions, OnboardingStep } from "./types";
 import type {
@@ -65,7 +64,10 @@ export const onboarding = <
 						);
 
 						if (step.once && completedSteps.has(id)) {
-							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
+							throw APIError.from(
+								"FORBIDDEN",
+								ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
+							);
 						}
 
 						if (
@@ -74,7 +76,10 @@ export const onboarding = <
 								.filter(([key]) => key !== id)
 								.some(([key]) => !completedSteps.has(key))
 						) {
-							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING);
+							throw APIError.from(
+								"FORBIDDEN",
+								ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
+							);
 						}
 
 						const result = await step.handler(ctx);
@@ -118,7 +123,10 @@ export const onboarding = <
 							);
 
 							if (completedSteps?.has(id)) {
-								throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
+								throw APIError.from(
+									"FORBIDDEN",
+									ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
+								);
 							}
 						}
 
@@ -146,14 +154,20 @@ export const onboarding = <
 						);
 
 						if (completedSteps.has(id)) {
-							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
+							throw APIError.from(
+								"FORBIDDEN",
+								ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
+							);
 						}
 						if (
 							requiredSteps
 								.filter(([key]) => key !== id)
 								.some(([key]) => !completedSteps.has(key))
 						) {
-							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING);
+							throw APIError.from(
+								"FORBIDDEN",
+								ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
+							);
 						}
 
 						await adapter.updateOnboardingState(session.user.id, {
@@ -215,7 +229,8 @@ export const onboarding = <
 				{
 					matcher(context) {
 						return (
-							!!opts.autoEnableOnSignUp && !!context.path?.startsWith("/sign-up")
+							!!opts.autoEnableOnSignUp &&
+							!!context.path?.startsWith("/sign-up")
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {

--- a/packages/plugins/onboarding/src/index.ts
+++ b/packages/plugins/onboarding/src/index.ts
@@ -42,7 +42,7 @@ export const onboarding = <
 			const key = transformPath(id);
 			const path = transformClientPath(id);
 
-			const endpoints: Record<string, AuthEndpoint> = {
+			const endpoints: Record<string, any> = {
 				[`onboardingStep${key}`]: createAuthEndpoint(
 					`/onboarding/step/${path}`,
 					{
@@ -65,9 +65,7 @@ export const onboarding = <
 						);
 
 						if (step.once && completedSteps.has(id)) {
-							throw new APIError("FORBIDDEN", {
-								message: ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
-							});
+							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
 						}
 
 						if (
@@ -76,10 +74,7 @@ export const onboarding = <
 								.filter(([key]) => key !== id)
 								.some(([key]) => !completedSteps.has(key))
 						) {
-							throw new APIError("FORBIDDEN", {
-								message:
-									ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
-							});
+							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING);
 						}
 
 						const result = await step.handler(ctx);
@@ -123,9 +118,7 @@ export const onboarding = <
 							);
 
 							if (completedSteps?.has(id)) {
-								throw new APIError("FORBIDDEN", {
-									message: ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
-								});
+								throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
 							}
 						}
 
@@ -153,19 +146,14 @@ export const onboarding = <
 						);
 
 						if (completedSteps.has(id)) {
-							throw new APIError("FORBIDDEN", {
-								message: ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
-							});
+							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED);
 						}
 						if (
 							requiredSteps
 								.filter(([key]) => key !== id)
 								.some(([key]) => !completedSteps.has(key))
 						) {
-							throw new APIError("FORBIDDEN", {
-								message:
-									ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
-							});
+							throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING);
 						}
 
 						await adapter.updateOnboardingState(session.user.id, {
@@ -227,7 +215,7 @@ export const onboarding = <
 				{
 					matcher(context) {
 						return (
-							opts.autoEnableOnSignUp && context.path.startsWith("/sign-up")
+							!!opts.autoEnableOnSignUp && !!context.path?.startsWith("/sign-up")
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {

--- a/packages/plugins/onboarding/src/onboarding.test.ts
+++ b/packages/plugins/onboarding/src/onboarding.test.ts
@@ -396,7 +396,8 @@ describe("Onboarding", () => {
 			});
 			expect(res.error?.status).toBe(403);
 			expect(res.error?.code).toBe(
-				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
+				ONBOARDING_ERROR_CODES
+					.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
 			);
 		});
 
@@ -492,7 +493,8 @@ describe("Onboarding", () => {
 
 			expect(res.error?.status).toBe(403);
 			expect(res.error?.code).toBe(
-				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
+				ONBOARDING_ERROR_CODES
+					.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
 			);
 		});
 

--- a/packages/plugins/onboarding/src/onboarding.test.ts
+++ b/packages/plugins/onboarding/src/onboarding.test.ts
@@ -130,7 +130,7 @@ describe("Onboarding", () => {
 				},
 			});
 			expect(error?.status).toBe(403);
-			expect(error?.message).toBe(ONBOARDING_ERROR_CODES.ALREADY_ONBOARDED);
+			expect(error?.code).toBe(ONBOARDING_ERROR_CODES.ALREADY_ONBOARDED.code);
 		});
 
 		it("should fail shouldOnboard without session", async () => {
@@ -395,8 +395,8 @@ describe("Onboarding", () => {
 				fetchOptions: { headers },
 			});
 			expect(res.error?.status).toBe(403);
-			expect(res.error?.message).toBe(
-				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
+			expect(res.error?.code).toBe(
+				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
 			);
 		});
 
@@ -491,8 +491,8 @@ describe("Onboarding", () => {
 			});
 
 			expect(res.error?.status).toBe(403);
-			expect(res.error?.message).toBe(
-				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING,
+			expect(res.error?.code).toBe(
+				ONBOARDING_ERROR_CODES.COMPLETE_REQUIRED_STEPS_BEFORE_COMPLETING_ONBOARDING.code,
 			);
 		});
 

--- a/packages/plugins/onboarding/src/presets/setup-2fa.test.ts
+++ b/packages/plugins/onboarding/src/presets/setup-2fa.test.ts
@@ -88,8 +88,8 @@ describe("setup-2fa preset", async () => {
 			fetchOptions: { headers },
 		});
 		expect(res.error?.status).toBe(403);
-		expect(res.error?.message).toBe(
-			ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED,
+		expect(res.error?.code).toBe(
+			ONBOARDING_ERROR_CODES.STEP_ALREADY_COMPLETED.code,
 		);
 	});
 });

--- a/packages/plugins/onboarding/src/presets/setup-new-password.test.ts
+++ b/packages/plugins/onboarding/src/presets/setup-new-password.test.ts
@@ -61,7 +61,7 @@ describe("setup-new-password preset", async () => {
 			fetchOptions: { headers },
 		});
 		expect(res.error?.status).toBe(400);
-		expect(res.error?.message).toContain("Invalid body parameters");
+		expect(res.error?.message).toContain("Passwords do not match");
 	});
 
 	it("should successfully update password when passwords match", async () => {

--- a/packages/plugins/onboarding/src/presets/setup-new-password.ts
+++ b/packages/plugins/onboarding/src/presets/setup-new-password.ts
@@ -47,7 +47,6 @@ export const setupNewPasswordStep = <O extends SetupNewPasswordStepOptions>(
 			await ctx.context.internalAdapter.updatePassword(
 				session.user.id,
 				ctx.body.newPassword,
-				ctx,
 			);
 
 			return {

--- a/packages/plugins/onboarding/src/verify-onboarding.ts
+++ b/packages/plugins/onboarding/src/verify-onboarding.ts
@@ -25,9 +25,7 @@ export async function verifyOnboarding(
 		shouldOnboard = await adapter.getShouldOnboard(session.user.id);
 	}
 	if (!shouldOnboard) {
-		throw new APIError("FORBIDDEN", {
-			message: ONBOARDING_ERROR_CODES.ALREADY_ONBOARDED,
-		});
+		throw APIError.from("FORBIDDEN", ONBOARDING_ERROR_CODES.ALREADY_ONBOARDED);
 	}
 
 	return {

--- a/packages/plugins/preferences/src/error-codes.ts
+++ b/packages/plugins/preferences/src/error-codes.ts
@@ -1,7 +1,9 @@
-export const PREFERENCES_ERROR_CODES = {
+import { defineErrorCodes } from "better-auth";
+
+export const PREFERENCES_ERROR_CODES = defineErrorCodes({
 	PREFERENCE_SCOPE_NOT_FOUND: "Scope not found",
 	PREFERENCE_SCOPE_PREFERENCE_NOT_FOUND: "Scope preference not found",
 	PREFERENCE_SCOPE_ID_IS_REQUIRED: "Scope id is required",
 	PREFERENCE_MISSING_PERMISSION: "Missing permission",
 	PREFERENCES_ADMIN_PLUGIN_NOT_SETUP: "Admin plugin is not set up",
-} as const;
+});

--- a/packages/plugins/preferences/src/index.ts
+++ b/packages/plugins/preferences/src/index.ts
@@ -268,12 +268,12 @@ export const preferences = <
 							});
 						},
 					),
-				} as Record<string, AuthEndpoint>);
+				} as Record<string, any>);
 			});
 
 			const groupEndpoints = scope.groups
 				? Object.entries(scope.groups).flatMap(([key, config]) => {
-						const endpoints: Record<string, AuthEndpoint> = {};
+						const endpoints: Record<string, any> = {};
 						const groupKey = transformPath(key);
 						const groupPath = `${encodeURIComponent("$")}${transformClientPath(key)}`;
 

--- a/packages/plugins/preferences/src/index.ts
+++ b/packages/plugins/preferences/src/index.ts
@@ -21,7 +21,7 @@ import {
 	transformClientPath,
 	transformPath,
 } from "./utils";
-import { createAuthEndpoint, type AuthEndpoint } from "better-auth/api";
+import { createAuthEndpoint } from "better-auth/api";
 import { schema, type PreferenceInput } from "./schema";
 import { preferencesMiddleware } from "./call";
 import { mergeSchema } from "better-auth/db";

--- a/packages/plugins/preferences/src/utils/check-scope-permission.ts
+++ b/packages/plugins/preferences/src/utils/check-scope-permission.ts
@@ -57,7 +57,7 @@ export const checkScopePermission = async (
 
 	if (!hasPerm) {
 		throw ctx.error("FORBIDDEN", {
-			message: PREFERENCES_ERROR_CODES.PREFERENCE_MISSING_PERMISSION,
+			...PREFERENCES_ERROR_CODES.PREFERENCE_MISSING_PERMISSION,
 		});
 	}
 };
@@ -83,7 +83,7 @@ const checkPermission = async (
 	if (!adminPlugin) {
 		ctx.context.logger.error("Admin plugin is not set-up.");
 		throw ctx.error("FAILED_DEPENDENCY", {
-			message: PREFERENCES_ERROR_CODES.PREFERENCES_ADMIN_PLUGIN_NOT_SETUP,
+			...PREFERENCES_ERROR_CODES.PREFERENCES_ADMIN_PLUGIN_NOT_SETUP,
 		});
 	}
 

--- a/packages/plugins/preferences/src/utils/check-scope.ts
+++ b/packages/plugins/preferences/src/utils/check-scope.ts
@@ -10,18 +10,18 @@ export const checkScope = (
 	const scope = options.scopes[data.scope];
 	if (!scope) {
 		throw ctx.error("BAD_REQUEST", {
-			message: PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_NOT_FOUND,
+			...PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_NOT_FOUND,
 		});
 	}
 	const config = scope.preferences[data.key];
 	if (!config) {
 		throw ctx.error("BAD_REQUEST", {
-			message: PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_PREFERENCE_NOT_FOUND,
+			...PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_PREFERENCE_NOT_FOUND,
 		});
 	}
 	if (!data.scopeId && scope.requireScopeId) {
 		throw ctx.error("BAD_REQUEST", {
-			message: PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_ID_IS_REQUIRED,
+			...PREFERENCES_ERROR_CODES.PREFERENCE_SCOPE_ID_IS_REQUIRED,
 		});
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.3.0
       version: 0.3.0
     better-auth:
-      specifier: ^1.3.34
-      version: 1.3.34
+      specifier: ^1.5.5
+      version: 1.5.5
   default:
     '@better-fetch/fetch':
       specifier: ^1.1.18
@@ -275,7 +275,7 @@ importers:
     devDependencies:
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(typescript@5.9.3)
@@ -297,7 +297,7 @@ importers:
     devDependencies:
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(typescript@5.9.3)
@@ -316,7 +316,7 @@ importers:
     devDependencies:
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(typescript@5.9.3)
@@ -344,7 +344,7 @@ importers:
         version: link:../../libraries/test-utils
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       better-call:
         specifier: 'catalog:'
         version: 1.0.19
@@ -375,7 +375,7 @@ importers:
         version: 7.6.13
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       better-call:
         specifier: 'catalog:'
         version: 1.0.19
@@ -412,7 +412,7 @@ importers:
         version: 7.6.13
       better-auth:
         specifier: catalog:better-auth
-        version: 1.3.34
+        version: 1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
       better-call:
         specifier: 'catalog:'
         version: 1.0.19
@@ -474,14 +474,82 @@ packages:
       kysely: ^0.28.5
       nanostores: ^1.0.1
 
+  '@better-auth/core@1.5.5':
+    resolution: {integrity: sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==}
+    peerDependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@cloudflare/workers-types': '>=4'
+      better-call: 1.3.2
+      jose: ^6.1.0
+      kysely: ^0.28.5
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.5.5':
+    resolution: {integrity: sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
+      '@better-auth/utils': ^0.3.0
+      drizzle-orm: '>=0.41.0'
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.5.5':
+    resolution: {integrity: sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
+      '@better-auth/utils': ^0.3.0
+      kysely: ^0.27.0 || ^0.28.0
+
+  '@better-auth/memory-adapter@1.5.5':
+    resolution: {integrity: sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
+      '@better-auth/utils': ^0.3.0
+
+  '@better-auth/mongo-adapter@1.5.5':
+    resolution: {integrity: sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
+      '@better-auth/utils': ^0.3.0
+      mongodb: ^6.0.0 || ^7.0.0
+
+  '@better-auth/prisma-adapter@1.5.5':
+    resolution: {integrity: sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
+      '@better-auth/utils': ^0.3.0
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
   '@better-auth/telemetry@1.3.34':
     resolution: {integrity: sha512-aQZ3wN90YMqV49diWxAMe1k7s2qb55KCsedCZne5PlgCjU4s3YtnqyjC5FEpzw2KY8l8rvR7DMAsDl13NjObKA==}
+
+  '@better-auth/telemetry@1.5.5':
+    resolution: {integrity: sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ==}
+    peerDependencies:
+      '@better-auth/core': 1.5.5
 
   '@better-auth/utils@0.3.0':
     resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
 
+  '@better-auth/utils@0.3.1':
+    resolution: {integrity: sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==}
+
   '@better-fetch/fetch@1.1.18':
     resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
+
+  '@better-fetch/fetch@1.1.21':
+    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -977,6 +1045,9 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@mongodb-js/saslprep@1.4.6':
+    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
+
   '@nanostores/persistent@1.2.0':
     resolution: {integrity: sha512-kf5WOLpVI9Pk+AwXHIax4in3pesNe8299BEGQ2H8kgI05SZw7KKWCDv7bt2FOlND8E5y7rO5PRW34q0UCAl/DA==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -1046,6 +1117,10 @@ packages:
 
   '@noble/ciphers@2.0.1':
     resolution: {integrity: sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@2.0.1':
@@ -2009,6 +2084,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -2224,6 +2302,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -2392,8 +2476,78 @@ packages:
       vue:
         optional: true
 
+  better-auth@1.5.5:
+    resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: '>=0.41.0'
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
   better-call@1.0.19:
     resolution: {integrity: sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw==}
+
+  better-call@1.3.2:
+    resolution: {integrity: sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -2424,6 +2578,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -3211,6 +3369,9 @@ packages:
   jose@6.1.0:
     resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
 
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -3232,6 +3393,10 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  kysely@0.28.11:
+    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+    engines: {node: '>=20.0.0'}
 
   kysely@0.28.5:
     resolution: {integrity: sha512-rlB0I/c6FBDWPcQoDtkxi9zIvpmnV5xoIalfCMSMCa7nuA6VGA3F54TW9mEgX4DVf10sXAWCF5fDbamI/5ZpKA==}
@@ -3435,6 +3600,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3580,6 +3748,37 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.1.0:
+    resolution: {integrity: sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
   motion-dom@12.23.23:
     resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
 
@@ -3617,6 +3816,10 @@ packages:
 
   nanostores@1.0.1:
     resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  nanostores@1.1.1:
+    resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-build-utils@2.0.0:
@@ -3880,6 +4083,10 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
 
@@ -4080,6 +4287,9 @@ packages:
   rou3@0.5.1:
     resolution: {integrity: sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==}
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -4125,6 +4335,9 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  set-cookie-parser@3.0.1:
+    resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
 
   sharp@0.34.4:
     resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
@@ -4190,6 +4403,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -4344,6 +4560,10 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4638,6 +4858,14 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4672,6 +4900,9 @@ packages:
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4717,6 +4948,44 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.1.12
 
+  '@better-auth/core@1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)':
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.2(zod@4.3.6)
+      jose: 6.2.1
+      kysely: 0.28.11
+      nanostores: 1.1.1
+      zod: 4.3.6
+
+  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+
+  '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+      kysely: 0.28.11
+
+  '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+
+  '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+      mongodb: 7.1.0(socks@2.8.7)
+
+  '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+
   '@better-auth/telemetry@1.3.34(better-call@1.0.19)(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)':
     dependencies:
       '@better-auth/core': 1.3.34(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
@@ -4728,9 +4997,19 @@ snapshots:
       - kysely
       - nanostores
 
+  '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))':
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+
   '@better-auth/utils@0.3.0': {}
 
+  '@better-auth/utils@0.3.1': {}
+
   '@better-fetch/fetch@1.1.18': {}
+
+  '@better-fetch/fetch@1.1.21': {}
 
   '@biomejs/biome@2.3.2':
     optionalDependencies:
@@ -5217,6 +5496,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mongodb-js/saslprep@1.4.6':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@nanostores/persistent@1.2.0(nanostores@1.0.1)':
     dependencies:
       nanostores: 1.0.1
@@ -5260,6 +5543,8 @@ snapshots:
     optional: true
 
   '@noble/ciphers@2.0.1': {}
+
+  '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -6207,6 +6492,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6439,6 +6726,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/og@0.8.5':
@@ -6585,6 +6878,35 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.1.12
 
+  better-auth@1.5.5(better-sqlite3@12.4.1)(mongodb@7.1.0(socks@2.8.7))(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)):
+    dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
+      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.3.2(zod@4.3.6)
+      defu: 6.1.4
+      jose: 6.2.1
+      kysely: 0.28.11
+      nanostores: 1.1.1
+      zod: 4.3.6
+    optionalDependencies:
+      better-sqlite3: 12.4.1
+      mongodb: 7.1.0(socks@2.8.7)
+      next: 15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+
   better-call@1.0.19:
     dependencies:
       '@better-auth/utils': 0.3.0
@@ -6592,6 +6914,15 @@ snapshots:
       rou3: 0.5.1
       set-cookie-parser: 2.7.1
       uncrypto: 0.1.3
+
+  better-call@1.3.2(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.0.1
+    optionalDependencies:
+      zod: 4.3.6
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -6628,6 +6959,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bson@7.2.0: {}
 
   buffer@5.7.1:
     dependencies:
@@ -7510,6 +7843,8 @@ snapshots:
 
   jose@6.1.0: {}
 
+  jose@6.2.1: {}
+
   js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
@@ -7532,6 +7867,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  kysely@0.28.11: {}
 
   kysely@0.28.5: {}
 
@@ -7804,6 +8141,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  memory-pager@1.5.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -8102,6 +8441,19 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.1.0(socks@2.8.7):
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
+    optionalDependencies:
+      socks: 2.8.7
+
   motion-dom@12.23.23:
     dependencies:
       motion-utils: 12.23.6
@@ -8125,6 +8477,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.0.1: {}
+
+  nanostores@1.1.1: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -8432,6 +8786,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   pvtsutils@1.3.6:
     dependencies:
       tslib: 2.8.1
@@ -8716,6 +9072,8 @@ snapshots:
 
   rou3@0.5.1: {}
 
+  rou3@0.7.12: {}
+
   run-async@2.4.1: {}
 
   run-parallel@1.2.0:
@@ -8764,6 +9122,8 @@ snapshots:
       upper-case-first: 1.1.2
 
   set-cookie-parser@2.7.1: {}
+
+  set-cookie-parser@3.0.1: {}
 
   sharp@0.34.4:
     dependencies:
@@ -8854,6 +9214,10 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
 
   spawndamnit@3.0.1:
     dependencies:
@@ -8994,6 +9358,10 @@ snapshots:
       vfile: 6.0.3
 
   toad-cache@3.7.0: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -9313,6 +9681,13 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -9340,5 +9715,7 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zod@4.1.12: {}
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,6 @@ catalog:
 catalogs:
   better-auth:
     "@better-auth/utils": ^0.3.0
-    better-auth: ^1.3.34
+    better-auth: ^1.5.5
 
 neverBuiltDependencies: []


### PR DESCRIPTION
## Upgrade better-auth to 1.5.x

Upgrades the `better-auth` dependency from `^1.3.34` to `^1.5.3` across all packages and adapts to breaking API changes introduced in 1.5.

### Changes

- **Dependency**: Bumped `better-auth` in `pnpm-workspace.yaml` catalog from `^1.3.34` to `^1.5.3`
- **Error codes**: Migrated all error code definitions to use `defineErrorCodes()` from `better-auth`, producing structured `{ code, message }` objects instead of plain strings (`app-invite`, `onboarding`, `preferences`)
- **Error handling**: Replaced `throw new APIError("STATUS", { message })` with `throw APIError.from("STATUS", ERROR_CODE)` across all route handlers
- **Import paths**: Updated `createAuthEndpoint` imports from `better-auth/plugins` to `better-auth/api`, and `getMigrations` from `better-auth/db` to `better-auth/db/migration`
- **API signatures**: Removed deprecated `ctx` argument from `internalAdapter.linkAccount()` and `internalAdapter.createSession()` calls
- **Type fixes**: Updated `InferFieldsInput` to `InferDBFieldsInput`, replaced `AuthEndpoint` (now requires 3 type args) with `any` for dynamic endpoint records, added `as string` cast for widened `BaseURLConfig` type
- **Tests**: Updated assertions to check `error.code` instead of `error.message` for structured error codes, and adjusted expected Zod validation error messages

### Packages affected

- `@better-auth-extended/app-invite`
- `@better-auth-extended/onboarding`
- `@better-auth-extended/preferences`
- `@better-auth-extended/test-utils`

### Breaking changes

Error code exports (e.g. `APP_INVITE_ERROR_CODES`, `ONBOARDING_ERROR_CODES`, `PREFERENCES_ERROR_CODES`) are now objects with `{ code, message }` instead of plain strings. Consumers comparing against these values will need to update accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `better-auth` to 1.5.x and migrate our plugins to the new API: structured error codes, new import paths, and adapter signature updates. Major bumps for `@better-auth-extended/*` due to breaking error-code exports.

- **Dependencies**
  - Bumped `better-auth` catalog to `^1.5.5` and refreshed the lockfile.
  - Adopted `defineErrorCodes()` and `APIError.from()`; tests now assert `error.code`.
  - Moved imports to `better-auth/api` and `better-auth/db/migration`; replaced `InferFieldsInput` with `InferDBFieldsInput`.
  - Minor lint/type fixes for the 1.5 API (boolean matcher checks, endpoint map typing, baseURL cast).
  - Major bumps for `@better-auth-extended/app-invite`, `@better-auth-extended/onboarding`, `@better-auth-extended/preferences`, `@better-auth-extended/test-utils`.

- **Migration**
  - Error codes are now objects; compare `error.code` and use exported constants’ `.code`/`.message`.
  - Update imports to `better-auth/api` and `better-auth/db/migration` if you extend our endpoints or use test utils.
  - Remove the `ctx` argument from `internalAdapter.linkAccount()`, `internalAdapter.createSession()`, and `internalAdapter.updatePassword()` calls.

<sup>Written for commit 464c00886fb894b81232516189debb658ed7f5ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

